### PR TITLE
Detail View Work

### DIFF
--- a/res/layout/fragment_basicdetails.xml
+++ b/res/layout/fragment_basicdetails.xml
@@ -1,104 +1,86 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/backgroundContainer"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-     >
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/scrollView"
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent" >
 
-    <TextView
-        android:id="@+id/animeStatusLabel"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_alignParentRight="true"
-        android:layout_marginRight="8dp"
-        android:layout_marginTop="8dp"
-        android:background="#AA000000"
-        android:padding="4dp"
-        android:text="ANIME STATUS"
-        android:textAppearance="?android:attr/textAppearanceSmall"
-        android:textColor="#FFFFFF" />
+	<RelativeLayout
+	    android:id="@+id/backgroundContainer"
+	    android:layout_width="match_parent"
+	    android:layout_height="wrap_content"
+	    android:padding="8dp" >
+	
+	    <TextView
+	        android:id="@+id/itemTitle"
+	        android:layout_width="wrap_content"
+	        android:layout_height="wrap_content"
+	        android:layout_centerInParent="true"
+	        android:layout_alignParentTop="true"
+	        android:paddingBottom="8dp"
+	        android:text="ItemTitle"
+	        android:textAppearance="?android:attr/textAppearanceLarge" />
+	    
+	    <!--  TODO: Set up a default image placeholder -->
+	    <ImageView
+	        android:id="@+id/detailCoverImage"
+	        android:layout_width="225dp"
+	        android:layout_height="wrap_content"
+	        android:minHeight="320dp"
+	        android:scaleType="centerCrop"
+	        android:paddingRight="10dp"
+	        android:paddingBottom="30dp"
+	        android:layout_below="@id/itemTitle"
+	        android:contentDescription="@string/description_CoverImage" />
+	    
+	    <TextView
+	        android:id="@+id/animeTypeLabel"
+	        android:layout_width="wrap_content"
+	        android:layout_height="wrap_content"
+	        android:layout_below="@id/itemTitle"
+	        android:layout_toRightOf="@id/detailCoverImage"
+	        android:text="Type" />
+	    
+	    <TextView
+	        android:id="@+id/animeStatusLabel"
+	        android:layout_width="wrap_content"
+	        android:layout_height="wrap_content"
+	        android:layout_toRightOf="@id/detailCoverImage"
+	        android:layout_below="@id/animeTypeLabel"
+	        android:text="Status" />
 
-    <TextView
-        android:id="@+id/animeTypeLabel"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_alignParentTop="true"
-        android:layout_marginRight="8dp"
-        android:layout_marginTop="8dp"
-        android:layout_toLeftOf="@id/animeStatusLabel"
-        android:background="#AA000000"
-        android:padding="4dp"
-        android:text="ANIME TYPE"
-        android:textAppearance="?android:attr/textAppearanceSmall"
-        android:textColor="#FFFFFF" />
+	    <TextView
+	        android:id="@+id/animeMyStatusLabel"
+	        android:layout_width="wrap_content"
+	        android:layout_height="wrap_content"
+	        android:layout_toRightOf="@id/detailCoverImage"
+	        android:layout_below="@id/animeStatusLabel"
+	        android:text="ViewStatus" />
+	
+		<TextView
+		    android:id="@+id/animeEpisodesWatchedCounterLabel"
+		    android:layout_width="wrap_content"
+		    android:layout_height="wrap_content"
+		    android:layout_alignParentLeft="false"
+	        android:layout_toRightOf="@id/detailCoverImage"
+	        android:layout_below="@id/animeMyStatusLabel"
+		    android:text="0 / 12"
+		    android:textAppearance="?android:attr/textAppearanceSmall" />
+	
+		<TextView
+		    android:id="@+id/SynopsisLabel"
+		    android:layout_width="match_parent"
+		    android:layout_height="wrap_content"
+			android:layout_below="@id/detailCoverImage"
+		    android:text="Synopsis"
+		    android:textAppearance="?android:attr/textAppearanceLarge" />
+		
+		<TextView
+		    android:id="@+id/Synopsis"
+		    android:layout_width="match_parent"
+		    android:layout_height="wrap_content"
+		    android:layout_below="@id/SynopsisLabel"
+		    android:padding="8dp"
+		    android:text="@string/placeholder_Loading" />
 
-    <TextView
-        android:id="@+id/animeMyStatusLabel"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_alignParentLeft="false"
-        android:layout_marginLeft="8dp"
-        android:layout_marginTop="8dp"
-        android:background="#AA000000"
-        android:padding="4dp"
-        android:text="MY STATUS"
-        android:textAppearance="?android:attr/textAppearanceSmall"
-        android:textColor="#FFFFFF" />
-
-    <TextView
-        android:id="@+id/animeEpisodesWatchedCounterLabel"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_alignParentLeft="false"
-        android:layout_marginLeft="8dp"
-        android:layout_marginTop="8dp"
-        android:layout_toRightOf="@id/animeMyStatusLabel"
-        android:background="#AA000000"
-        android:padding="4dp"
-        android:text="0 / 12"
-        android:textAppearance="?android:attr/textAppearanceSmall"
-        android:textColor="#FFFFFF" />
-
-    <ScrollView
-        android:id="@+id/scrollView"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:fillViewport="false"
-        android:overScrollMode="never"
-        android:scrollbars="none" >
-
-        <LinearLayout
-            android:id="@+id/innerLayout"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="vertical" >
-
-            <TextView
-                android:id="@+id/SynopsisLabel"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_alignBottom="@id/backgroundContainer"
-                android:layout_alignParentBottom="true"
-                android:background="#AA000000"
-                android:paddingBottom="16dp"
-                android:paddingLeft="16dp"
-                android:paddingTop="16dp"
-                android:text="Synopsis"
-                android:textAppearance="?android:attr/textAppearanceLarge"
-                android:textColor="#FFFFFF" />
-
-            <TextView
-                android:id="@+id/Synopsis"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_below="@id/SynopsisLabel"
-                android:background="#AA000000"
-                android:paddingBottom="16dp"
-                android:paddingLeft="16dp"
-                android:paddingRight="16dp"
-                android:text="@string/placeholder_Loading"
-                android:textColor="#FFFFFF" />
-        </LinearLayout>
-    </ScrollView>
-
-</RelativeLayout>
+	</RelativeLayout>
+</ScrollView>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -45,6 +45,7 @@
     <string name="preference_category_ListSettings">List Settings</string>
     <string name="dialog_DefaultList">Default List</string>
     <string name="summary_DefaultList">Which list do you want the app to load when opened?</string>
+    <string name="description_CoverImage">Cover Image</string>
     <string-array name="listTypeArray">
         <item >Everything</item>
         <item >Watching</item>

--- a/src/net/somethingdreadful/MAL/AnimeRecord.java
+++ b/src/net/somethingdreadful/MAL/AnimeRecord.java
@@ -1,5 +1,7 @@
 package net.somethingdreadful.MAL;
 
+import android.text.Html;
+import android.text.Spanned;
 import net.somethingdreadful.MAL.R;
 
 public class AnimeRecord extends GenericMALRecord {
@@ -102,11 +104,17 @@ public class AnimeRecord extends GenericMALRecord {
 		return memberScore;
 	}
 
+	// Use this to get the raw HTML-formatted synopsis
 	public String getSynopsis() {
 		
 		return synopsis;
 	}
 	
+	// Use this to get a formatted version of the text suited for display in the application
+	public Spanned getSpannedSynopsis() {
+		return Html.fromHtml(synopsis);
+	}
+
 	public void setSynopsis(String newSynopsis)
 	{
 		this.synopsis = newSynopsis;

--- a/src/net/somethingdreadful/MAL/DetailsBasicFragment.java
+++ b/src/net/somethingdreadful/MAL/DetailsBasicFragment.java
@@ -48,24 +48,6 @@ public class DetailsBasicFragment extends Fragment {
     	return layout;
     }
     
-    public void positionSynopsis()
-    {
-    	
-    	
-    	
-    	int synopsisOffset = layout.getHeight();
-	      synopsisOffset -= layout.findViewById(R.id.SynopsisLabel).getHeight();
-	      System.out.println(synopsisOffset);
-	    	
-	    	
-	      LayoutParams params = (LayoutParams) layout.findViewById(R.id.SynopsisLabel).getLayoutParams();
-	      params.setMargins(0, synopsisOffset, 0, 0);
-	      layout.findViewById(R.id.SynopsisLabel).setLayoutParams(params);
-	      
-	      layout.invalidate();
-	    	
-    }
-    
     @Override
     public void onCreate(Bundle state)
     {
@@ -78,7 +60,6 @@ public class DetailsBasicFragment extends Fragment {
     	super.onResume();
     	
     	fragmentInterface.basicFragmentReady();
-//    	positionSynopsis();
     }
     
     @Override

--- a/src/net/somethingdreadful/MAL/MALManager.java
+++ b/src/net/somethingdreadful/MAL/MALManager.java
@@ -273,9 +273,7 @@ public class MALManager {
 	{
 		JSONObject o = getAnimeDetails(id);
 		
-		ar.setSynopsis(getDataFromJSON(o, "synopsis")
-				.replace("<br>", "\n").replace("&amp;", "&").replace("&rsquo;", "'")
-				.replace("<strong>", "").replace("</strong>", ""));
+		ar.setSynopsis(getDataFromJSON(o, "synopsis"));
 		
 		insertOrUpdateAnime(ar, false);
 		


### PR DESCRIPTION
This is a rough start on a new detail view. It will likely need to be worked to handle narrow screens such as phones and needs some work on the information presentation to make it cleaner and more appealing. However, it's functional and clean. It also eliminates the kludge of having to wait to properly position the synopsis around the action bar as the presentation is changed to something that doesn't have that issue.

Also done are some changes to the synopsis text display. Now, the raw HTML is retained and used to format the display on the detail page. This has the benefit of keeping the original styling while also avoiding having to parse out tags and entities such as &mdash;. Instead, they are properly retained and displayed.

**Before you merge this in**, I highly suggest merging current working back to master (as it was released as a 1.0) and tagging the 1.0 release code. This will also allow fixing issue #6 and any other major issues on a maintenance branch so a bugfix release can be made without pulling in these changes until they are ready for release.
