### PR TITLE
Fix search results was not using the right url.

### DIFF
--- a/Atarashii/src/net/somethingdreadful/MAL/api/MALApi.java
+++ b/Atarashii/src/net/somethingdreadful/MAL/api/MALApi.java
@@ -12,6 +12,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import android.content.Context;
+import android.net.Uri;
 import android.util.Log;
 
 public class MALApi extends BaseMALApi {
@@ -81,8 +82,8 @@ public class MALApi extends BaseMALApi {
 		URL url;
 		RestResult<String> response = null;
 		try {
-			url = new URL(getFullPath(getListTypeString(listType)
-					+ String.format("/search?q=%s", query)));
+			url = new URL(getFullPath(getListTypeString(listType) + "/search?q=" 
+					+ Uri.encode(query)));
 			response = restHelper.get(url);
 		} catch (MalformedURLException e) {
 			Log.e(TAG, "Something went wrong, returning an empty list instead of null", e);


### PR DESCRIPTION
The search method was requesting an invalid url.
This was the cause of not returning the right anime/manga details.

It was only searching for the first word.

Example of the url atarashii requested: http://api.atarashiiapp.com/anime/search?q=mirai nikki
The way it should be requested: http://api.atarashiiapp.com/anime/search?q=mirai%20nikki
