### PR TITLE
Border for cards

### DIFF
--- a/Atarashii/res/drawable/cardborder.xml
+++ b/Atarashii/res/drawable/cardborder.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <shape>
+            <corners
+              android:radius="2dp" />
+            <solid
+              android:color="@color/cardborder_shadow2" />
+        </shape>
+    </item>
+    <item android:bottom="1px">
+        <shape>
+            <corners
+              android:radius="2dp" />
+            <solid
+              android:color="@color/cardborder_shadow" />
+        </shape>
+    </item>
+    <item android:bottom="2px">
+		<shape android:shape="rectangle">
+		  <corners
+		      android:radius="2dp" />
+		  <stroke
+		      android:width="1px"
+		      android:color="@color/cardborder" />
+		  <solid
+		      android:color="@android:color/white" />
+		</shape>
+	</item>
+</layer-list>

--- a/Atarashii/res/layout/activity_about.xml
+++ b/Atarashii/res/layout/activity_about.xml
@@ -46,9 +46,9 @@
             android:layout_marginLeft="8dp"
             android:layout_marginRight="8dp"
             android:layout_marginTop="8dp"
-            android:background="#FFFFFF"
+            android:background="@drawable/cardborder"
             android:orientation="vertical"
-            android:padding="12dp" >
+            android:padding="12dp">
 
             <TextView
                 android:id="@+id/contributors_card_title"
@@ -123,7 +123,7 @@
             android:layout_marginLeft="8dp"
             android:layout_marginRight="8dp"
             android:layout_marginTop="8dp"
-            android:background="#FFFFFF"
+            android:background="@drawable/cardborder"
             android:orientation="vertical"
             android:padding="12dp" >
 
@@ -151,7 +151,7 @@
             android:layout_marginLeft="8dp"
             android:layout_marginRight="8dp"
             android:layout_marginTop="8dp"
-            android:background="#FFFFFF"
+            android:background="@drawable/cardborder"
             android:orientation="vertical"
             android:padding="12dp" >
 

--- a/Atarashii/res/layout/activity_profile.xml
+++ b/Atarashii/res/layout/activity_profile.xml
@@ -17,7 +17,7 @@
 		    android:layout_marginLeft="8dp"
 		    android:layout_marginRight="8dp"
 		    android:layout_marginTop="8dp"
-		    android:background="#FFFFFF"
+		    android:background="@drawable/cardborder"
 		    android:orientation="vertical">
             
 		    <TextView
@@ -55,7 +55,7 @@
             android:layout_marginLeft="8dp"
             android:layout_marginRight="8dp"
             android:layout_marginTop="8dp"
-            android:background="#FFFFFF"
+            android:background="@drawable/cardborder"
             android:orientation="vertical"
             android:padding="12dp" >
 
@@ -301,7 +301,7 @@
             android:layout_marginLeft="8dp"
             android:layout_marginRight="8dp"
             android:layout_marginTop="8dp"
-            android:background="#FFFFFF"
+            android:background="@drawable/cardborder"
             android:orientation="vertical"
             android:padding="12dp" >
 
@@ -466,7 +466,7 @@
             android:layout_marginLeft="8dp"
             android:layout_marginRight="8dp"
             android:layout_marginTop="8dp"
-            android:background="#FFFFFF"
+            android:background="@drawable/cardborder"
             android:orientation="vertical"
             android:padding="12dp" >
 

--- a/Atarashii/res/layout/card_layout_base.xml
+++ b/Atarashii/res/layout/card_layout_base.xml
@@ -6,7 +6,7 @@
     android:layout_marginLeft="8dp"
     android:layout_marginRight="8dp"
     android:layout_marginTop="8dp"
-    android:background="#FFFFFF"
+    android:background="@drawable/cardborder"
     android:padding="12dp" >
 
     <TextView

--- a/Atarashii/res/values/styles.xml
+++ b/Atarashii/res/values/styles.xml
@@ -4,6 +4,10 @@
     <color name="bg_dark">#333333</color>
     <color name="bg_light">#EEEEEE</color>
     
+    <color name="cardborder">#D2D2D2</color>
+    <color name="cardborder_shadow">#DADADA</color>
+    <color name="cardborder_shadow2">#e3e3e3</color>
+    
     <style name="AtarashiiLightBg" parent="Theme.Sherlock.Light.DarkActionBar">
         <item name="numberPickerStyle">@style/NPWidget.Holo.NumberPicker</item>
         <item name="android:windowBackground">@color/bg_light</item>


### PR DESCRIPTION
I added a border and a slight drop shadow to the cards in anime/manga details, profile and about screen to make it fit better to the usual card design as in googles and other apps.
I think it looks better this way, what do you think?

![card_01](https://f.cloud.github.com/assets/5774313/2163271/eb7e86f4-94dc-11e3-821c-443649503f52.png)
