### PR TITLE
Fix picasso offline crash & Traditional list stretch issue.

### DIFF
--- a/Atarashii/src/net/somethingdreadful/MAL/CoverAdapter.java
+++ b/Atarashii/src/net/somethingdreadful/MAL/CoverAdapter.java
@@ -99,7 +99,6 @@ public class CoverAdapter<T> extends ArrayAdapter<T> {
         .load(a.getImageUrl())
         .error(R.drawable.cover_error)
         .placeholder(R.drawable.cover_loading)
-        .fit()
         .into(viewHolder.cover);
 
         if (Build.VERSION.SDK_INT >= 11) {


### PR DESCRIPTION
My previous pull request (#84) was made on the working branch.
This time I moved it to a new branch.

The .fit() function caused some problems when atarashii was offline.
We could replace this with a try block but the Traditional list stretch issue wouldn't be fixed.

So I just removed the .fit(), the image still fit's perfect so this function was unnecessary for atarashii.
