### PR TITLE
cleanup isNetworkAvailable()

### DIFF
--- a/Atarashii/src/net/somethingdreadful/MAL/CoverAdapter.java
+++ b/Atarashii/src/net/somethingdreadful/MAL/CoverAdapter.java
@@ -3,6 +3,7 @@ package net.somethingdreadful.MAL;
 import java.util.ArrayList;
 import java.util.Collection;
 
+import net.somethingdreadful.MAL.api.MALApi;
 import net.somethingdreadful.MAL.api.response.Anime;
 import net.somethingdreadful.MAL.api.response.GenericRecord;
 import net.somethingdreadful.MAL.api.response.Manga;
@@ -10,8 +11,6 @@ import net.somethingdreadful.MAL.api.response.Manga;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.res.Resources;
-import android.net.ConnectivityManager;
-import android.net.NetworkInfo;
 import android.os.AsyncTask;
 import android.os.Build;
 import android.util.DisplayMetrics;
@@ -260,7 +259,7 @@ public class CoverAdapter<T> extends ArrayAdapter<T> {
                 internalManager.saveMangaToDatabase((Manga) gr[0], false);
             }
 
-            if (isNetworkAvailable()) {
+            if (MALApi.isNetworkAvailable(c)) {
                 if (MALManager.TYPE_ANIME.equals(internalType)) {
                     result = internalManager.writeAnimeDetailsToMAL((Anime) gr[0]);
                 } else {
@@ -291,19 +290,6 @@ public class CoverAdapter<T> extends ArrayAdapter<T> {
         DisplayMetrics metrics = resources.getDisplayMetrics();
         float px = dp * (metrics.densityDpi / 160f);
         return (int) px;
-    }
-
-    public boolean isNetworkAvailable() {
-        ConnectivityManager cm = (ConnectivityManager) c
-                .getSystemService(Context.CONNECTIVITY_SERVICE);
-        NetworkInfo netInfo = cm.getActiveNetworkInfo();
-        if (netInfo != null && netInfo.isConnected()) {
-            return true;
-        }
-        else {
-            return false;
-        }
-
     }
 
     static class ViewHolder {

--- a/Atarashii/src/net/somethingdreadful/MAL/DetailView.java
+++ b/Atarashii/src/net/somethingdreadful/MAL/DetailView.java
@@ -2,6 +2,7 @@ package net.somethingdreadful.MAL;
 
 import java.nio.charset.Charset;
 
+import net.somethingdreadful.MAL.api.MALApi;
 import net.somethingdreadful.MAL.api.response.Anime;
 import net.somethingdreadful.MAL.api.response.GenericRecord;
 import net.somethingdreadful.MAL.api.response.Manga;
@@ -11,8 +12,6 @@ import org.apache.commons.lang3.text.WordUtils;
 import android.annotation.TargetApi;
 import android.content.Context;
 import android.content.Intent;
-import android.net.ConnectivityManager;
-import android.net.NetworkInfo;
 import android.net.Uri;
 import android.nfc.NdefMessage;
 import android.nfc.NdefRecord;
@@ -113,7 +112,7 @@ RemoveConfirmationDialogFragment.RemoveConfirmationDialogListener {
         mManager = new MALManager(context);
         pManager = new PrefManager(context);
 
-        networkAvailable = isNetworkAvailable();
+        networkAvailable = MALApi.isNetworkAvailable(context);
 
 
         fm = getSupportFragmentManager();
@@ -971,18 +970,5 @@ RemoveConfirmationDialogFragment.RemoveConfirmationDialogListener {
         }
 
         setAddToListUI(false);
-    }
-
-    public boolean isNetworkAvailable() {
-        ConnectivityManager cm = (ConnectivityManager) context
-                .getSystemService(Context.CONNECTIVITY_SERVICE);
-        NetworkInfo netInfo = cm.getActiveNetworkInfo();
-        if (netInfo != null && netInfo.isConnected()) {
-            return true;
-        }
-        else {
-            return false;
-        }
-
     }
 }

--- a/Atarashii/src/net/somethingdreadful/MAL/FriendsActivity.java
+++ b/Atarashii/src/net/somethingdreadful/MAL/FriendsActivity.java
@@ -7,6 +7,7 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.Locale;
 
+import net.somethingdreadful.MAL.api.MALApi;
 import net.somethingdreadful.MAL.api.response.User;
 import net.somethingdreadful.MAL.tasks.FriendsNetworkTask;
 import net.somethingdreadful.MAL.tasks.FriendsNetworkTaskFinishedListener;
@@ -14,8 +15,6 @@ import net.somethingdreadful.MAL.tasks.FriendsNetworkTaskFinishedListener;
 import android.content.Context;
 import android.content.Intent;
 import android.graphics.Color;
-import android.net.ConnectivityManager;
-import android.net.NetworkInfo;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.LayoutInflater;
@@ -88,7 +87,7 @@ public class FriendsActivity extends SherlockFragmentActivity implements Friends
         try{
         	listadapter.supportAddAll(listarray);
         }catch (Exception e){
-        	if (isNetworkAvailable()){
+        	if (MALApi.isNetworkAvailable(context)){
     			Crouton.makeText(this, R.string.crouton_UserRecord_noFriends, Style.ALERT).show();
     		}else{
     			Crouton.makeText(this, R.string.crouton_noConnectivity, Style.ALERT).show();
@@ -110,7 +109,7 @@ public class FriendsActivity extends SherlockFragmentActivity implements Friends
 			finish();
 			break;
 		case R.id.forceSync:
-			if (isNetworkAvailable()){
+			if (MALApi.isNetworkAvailable(context)){
 				Crouton.makeText(this, R.string.crouton_SyncMessage, Style.INFO).show();
 				forcesync = true;
 				new FriendsNetworkTask(context, forcesync, this).execute(prefs.getUser());
@@ -120,16 +119,6 @@ public class FriendsActivity extends SherlockFragmentActivity implements Friends
 			break;
 		}
         return super.onOptionsItemSelected(item);
-    }
-	
-    public boolean isNetworkAvailable() {
-        ConnectivityManager cm = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
-        NetworkInfo netInfo = cm.getActiveNetworkInfo();
-        if (netInfo != null && netInfo.isConnected()) {
-            return true;
-        } else {
-            return false;
-        }
     }
 	
     public class ListViewAdapter<T> extends ArrayAdapter<T> {

--- a/Atarashii/src/net/somethingdreadful/MAL/Home.java
+++ b/Atarashii/src/net/somethingdreadful/MAL/Home.java
@@ -463,18 +463,6 @@ AnimeNetworkTaskFinishedListener, MangaNetworkTaskFinishedListener {
         lcdf.show(fm, "fragment_LogoutConfirmationDialog");
     }
 
-    public boolean isNetworkAvailable() {
-        ConnectivityManager cm = (ConnectivityManager) context
-                .getSystemService(Context.CONNECTIVITY_SERVICE);
-        NetworkInfo netInfo = cm.getActiveNetworkInfo();
-        if (netInfo != null && netInfo.isConnected()) {
-            return true;
-        }
-        else {
-            return false;
-        }
-    }
-
     public void maketext(String string) { //for the private class
         Crouton.makeText(this, string, Style.INFO).show();
     }
@@ -482,7 +470,7 @@ AnimeNetworkTaskFinishedListener, MangaNetworkTaskFinishedListener {
 
     public void checkNetworkAndDisplayCrouton() {
 
-        if (!isNetworkAvailable() && networkAvailable == true) {
+        if (!MALApi.isNetworkAvailable(context) && networkAvailable == true) {
     		Crouton.makeText(this, R.string.crouton_noConnectivityOnRun, Style.ALERT).show();
 
             af = (net.somethingdreadful.MAL.ItemGridFragment) mSectionsPagerAdapter.instantiateItem(mViewPager, 0);
@@ -495,14 +483,14 @@ AnimeNetworkTaskFinishedListener, MangaNetworkTaskFinishedListener {
 	            mf.getRecords(listType, "manga", false, Home.this.context);
 	            myList = true;
 	        }
-        } else if (isNetworkAvailable() && networkAvailable == false) {
+        } else if (MALApi.isNetworkAvailable(context) && networkAvailable == false) {
             Crouton.makeText(this, R.string.crouton_connectionRestored, Style.INFO).show();
 
             synctask();
 
         }
 
-        if (!isNetworkAvailable()) {
+        if (!MALApi.isNetworkAvailable(context)) {
             networkAvailable = false;
         } else {
             networkAvailable = true;
@@ -554,7 +542,7 @@ AnimeNetworkTaskFinishedListener, MangaNetworkTaskFinishedListener {
             /* do stuff when drawer item is clicked here */
             af.scrollToTop();
             mf.scrollToTop();
-            if (!isNetworkAvailable()) {
+            if (!MALApi.isNetworkAvailable(context)) {
                 if (position==0 || position==1 || position==2){
                 }else{
                     position = 1;

--- a/Atarashii/src/net/somethingdreadful/MAL/ProfileActivity.java
+++ b/Atarashii/src/net/somethingdreadful/MAL/ProfileActivity.java
@@ -1,5 +1,6 @@
 package net.somethingdreadful.MAL;
 
+import net.somethingdreadful.MAL.api.MALApi;
 import net.somethingdreadful.MAL.api.response.User;
 import net.somethingdreadful.MAL.tasks.UserNetworkTask;
 import net.somethingdreadful.MAL.tasks.UserNetworkTaskFinishedListener;
@@ -9,8 +10,6 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.graphics.Color;
-import android.net.ConnectivityManager;
-import android.net.NetworkInfo;
 import android.net.Uri;
 import android.os.Bundle;
 import android.view.View;
@@ -78,7 +77,7 @@ public class ProfileActivity extends SherlockFragmentActivity implements UserNet
                 finish();
                 break;
             case R.id.forceSync:
-            	if (isNetworkAvailable()){
+            	if (MALApi.isNetworkAvailable(context)){
             		Crouton.makeText(this, R.string.crouton_SyncMessage, Style.INFO).show();
             		forcesync = true;
             		String username;
@@ -102,16 +101,6 @@ public class ProfileActivity extends SherlockFragmentActivity implements UserNet
             	choosedialog(true);
         }
         return true;
-    }
-    
-    public boolean isNetworkAvailable() { //check if network is available
-        ConnectivityManager cm = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
-        NetworkInfo netInfo = cm.getActiveNetworkInfo();
-        if (netInfo != null && netInfo.isConnected()) {
-            return true;
-        } else {
-            return false;
-        }
     }
     
     public void card() { //settings for hide a card and text userprofile
@@ -277,7 +266,7 @@ public class ProfileActivity extends SherlockFragmentActivity implements UserNet
 			Crouton.makeText(this, R.string.crouton_UserRecord_updated, Style.CONFIRM).show();
     	}
     	if (record == null){
-    		if (!isNetworkAvailable()){
+    		if (!MALApi.isNetworkAvailable(context)){
     			Crouton.makeText(this, R.string.crouton_noUserRecord , Style.ALERT).show();
     		}else{
     			Crouton.makeText(this, R.string.crouton_UserRecord_error , Style.ALERT).show();

--- a/Atarashii/src/net/somethingdreadful/MAL/api/MALApi.java
+++ b/Atarashii/src/net/somethingdreadful/MAL/api/MALApi.java
@@ -21,6 +21,8 @@ import retrofit.client.ApacheClient;
 import retrofit.client.Response;
 
 import android.content.Context;
+import android.net.ConnectivityManager;
+import android.net.NetworkInfo;
 import android.os.Build;
 import android.util.Log;
 
@@ -73,6 +75,16 @@ public class MALApi {
             .build();
         friends_service = restAdapter.create(FriendsInterface.class);
 	}
+	
+    public static boolean isNetworkAvailable(Context context) {
+        ConnectivityManager cm = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
+        NetworkInfo netInfo = cm.getActiveNetworkInfo();
+        if (netInfo != null && netInfo.isConnected()) {
+            return true;
+        } else {
+            return false;
+        }
+    }
 
 	public boolean isAuth() {
 		try {

--- a/Atarashii/src/net/somethingdreadful/MAL/tasks/FriendsNetworkTask.java
+++ b/Atarashii/src/net/somethingdreadful/MAL/tasks/FriendsNetworkTask.java
@@ -3,11 +3,10 @@ package net.somethingdreadful.MAL.tasks;
 import java.util.ArrayList;
 
 import net.somethingdreadful.MAL.MALManager;
+import net.somethingdreadful.MAL.api.MALApi;
 import net.somethingdreadful.MAL.api.response.User;
 
 import android.content.Context;
-import android.net.ConnectivityManager;
-import android.net.NetworkInfo;
 import android.os.AsyncTask;
 import android.util.Log;
 
@@ -15,16 +14,6 @@ public class FriendsNetworkTask extends AsyncTask<String, Void, ArrayList<User>>
     private Context context;
     private boolean forcesync;
     FriendsNetworkTaskFinishedListener callback;
-    
-    private boolean isNetworkAvailable() {
-        ConnectivityManager cm = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
-        NetworkInfo netInfo = cm.getActiveNetworkInfo();
-        if (netInfo != null && netInfo.isConnected()) {
-            return true;
-        } else {
-            return false;
-        }
-    }
     
     public FriendsNetworkTask(Context context, boolean forcesync, FriendsNetworkTaskFinishedListener callback) {
         this.context = context;
@@ -41,11 +30,11 @@ public class FriendsNetworkTask extends AsyncTask<String, Void, ArrayList<User>>
         }
         MALManager mManager = new MALManager(context);
         
-        if ( forcesync && isNetworkAvailable() ) {
+        if ( forcesync && MALApi.isNetworkAvailable(context) ) {
             result = mManager.downloadAndStoreFriendList(params[0]);
         } else {
             result = mManager.getFriendListFromDB();
-            if ( ( result == null || result.isEmpty() ) && isNetworkAvailable() )
+            if ( ( result == null || result.isEmpty() ) && MALApi.isNetworkAvailable(context) )
                 result = mManager.downloadAndStoreFriendList(params[0]);
         }
         

--- a/Atarashii/src/net/somethingdreadful/MAL/tasks/UserNetworkTask.java
+++ b/Atarashii/src/net/somethingdreadful/MAL/tasks/UserNetworkTask.java
@@ -1,10 +1,9 @@
 package net.somethingdreadful.MAL.tasks;
 
 import net.somethingdreadful.MAL.MALManager;
+import net.somethingdreadful.MAL.api.MALApi;
 import net.somethingdreadful.MAL.api.response.User;
 import android.content.Context;
-import android.net.ConnectivityManager;
-import android.net.NetworkInfo;
 import android.os.AsyncTask;
 import android.util.Log;
 
@@ -18,16 +17,6 @@ public class UserNetworkTask extends AsyncTask<String, Void, User> {
         this.forcesync = forcesync;
         this.callback = callback;
     }
-    
-    private boolean isNetworkAvailable() {
-        ConnectivityManager cm = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
-        NetworkInfo netInfo = cm.getActiveNetworkInfo();
-        if (netInfo != null && netInfo.isConnected()) {
-            return true;
-        } else {
-            return false;
-        }
-    }
 
     @Override
     protected User doInBackground(String... params) {
@@ -39,11 +28,11 @@ public class UserNetworkTask extends AsyncTask<String, Void, User> {
         MALManager mManager = new MALManager(context);
         Log.d("MALX", "downloading profile of " + params[0]);
         
-        if ( forcesync && isNetworkAvailable() ) {
+        if ( forcesync && MALApi.isNetworkAvailable(context) ) {
            result = mManager.downloadAndStoreProfile(params[0]); 
         } else {
             result = mManager.getProfileFromDB(params[0]);
-            if ( result == null && isNetworkAvailable() )
+            if ( result == null && MALApi.isNetworkAvailable(context) )
                 result = mManager.downloadAndStoreProfile(params[0]);
         }
         return result;


### PR DESCRIPTION
Currently there are 7 implementations of isNetworkAvailable(). This PR adds isNetworkAvailable() as static function to MALApi (I think it is the right place as this class is the main networking class) and removes all other implementations.

Tested on Galaxy Nexus, no difference to previous behaviour.
