### PR TITLE
Fix wrong error crouton on friendlist

### DIFF
--- a/Atarashii/src/net/somethingdreadful/MAL/tasks/FriendsNetworkTask.java
+++ b/Atarashii/src/net/somethingdreadful/MAL/tasks/FriendsNetworkTask.java
@@ -29,13 +29,23 @@ public class FriendsNetworkTask extends AsyncTask<String, Void, ArrayList<User>>
             return null;
         }
         MALManager mManager = new MALManager(context);
-        
-        if ( forcesync && MALApi.isNetworkAvailable(context) ) {
-            result = mManager.downloadAndStoreFriendList(params[0]);
-        } else {
-            result = mManager.getFriendListFromDB();
-            if ( ( result == null || result.isEmpty() ) && MALApi.isNetworkAvailable(context) )
+        try {
+            if ( forcesync && MALApi.isNetworkAvailable(context) ) {
                 result = mManager.downloadAndStoreFriendList(params[0]);
+            } else {
+                result = mManager.getFriendListFromDB();
+                if ( ( result == null || result.isEmpty() ) && MALApi.isNetworkAvailable(context) )
+                    result = mManager.downloadAndStoreFriendList(params[0]);
+            }
+
+            /* returning null means there was an error, so return an empty ArrayList if there was no error
+             * but an empty result
+             */
+            if ( result == null )
+                result = new ArrayList<User>();
+        } catch (Exception e) {
+            Log.e("MALX", "error getting friendlist: " + e.getMessage());
+            result = null;
         }
         
         return result;


### PR DESCRIPTION
If the friendlist is empty and no network connection available, there is an wrong error crouton message displayed (empty friendlist is not an error). This PR changes the FriendNetworkTask to behave like Anime/MangaNetworkTask: it is now only returning null if there was an error, which makes error handling in the callback function easier.
