### PR TITLE
Fix share(profile) using int(id) instead string.

### DIFF
--- a/Atarashii/res/values/strings.xml
+++ b/Atarashii/res/values/strings.xml
@@ -38,7 +38,7 @@
     <string name="toast_SyncError">Sync Error! The API is currently unavailable.</string>
     <string name="toast_SyncMessage">Syncing everything. This could take a sec or two, depending on your internet speed.</string>
     <string name="toast_DetailsError">Could not load details, please check your Internet connection.</string>
-    
+
     <!-- All (Dialog Title & Contents) Strings -->
     <string name="dialog_label_cancel">Cancel</string>
     <string name="dialog_label_anime">My animelist</string>
@@ -55,8 +55,8 @@
     <string name="share_message">Which list do you want to share?</string>
 
     <!-- ProfileActivity (Contents) Strings -->
-    <string name="share_animelist">shared an anime list using Atarashii: http://myanimelist.net/animelist/</string>
-    <string name="share_mangalist">shared a manga list using Atarashii: http://myanimelist.net/mangalist/</string>
+    <string name="share_animelist">$username; shared an anime list using Atarashii: http://myanimelist.net/animelist/$name;!</string>
+    <string name="share_mangalist">$username; shared a manga list using Atarashii: http://myanimelist.net/mangalist/$name;!</string>
     <string name="layout_card_title_details">Details</string>
     <string name="layout_discription">Application Icon</string>
     <string name="layout_card_loading">Loading</string>

--- a/Atarashii/src/net/somethingdreadful/MAL/ProfileActivity.java
+++ b/Atarashii/src/net/somethingdreadful/MAL/ProfileActivity.java
@@ -144,18 +144,6 @@ public class ProfileActivity extends SherlockFragmentActivity implements UserNet
 		}
     }
     
-    public void Share(boolean anime) {
-        Intent sharingIntent = new Intent(android.content.Intent.ACTION_SEND);
-        sharingIntent.setType("text/plain");
-        sharingIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_WHEN_TASK_RESET);
-        if (anime == true){
-        	sharingIntent.putExtra(Intent.EXTRA_TEXT, record.getName() + " " + R.string.share_animelist + record.getName() + "!");
-        }else{
-        	sharingIntent.putExtra(Intent.EXTRA_TEXT, record.getName() + " " + R.string.share_mangalist + record.getName() + "!");
-        }
-        startActivity(Intent.createChooser(sharingIntent, "Share via"));
-    }
-    
     public void setcolor(boolean type){
     	int Hue = 0;
     	TextView textview = null;
@@ -284,9 +272,12 @@ public class ProfileActivity extends SherlockFragmentActivity implements UserNet
     
 	void choosedialog(final boolean share){ //as the name says
 		AlertDialog.Builder builder = new AlertDialog.Builder(this);
+		final Intent sharingIntent = new Intent(android.content.Intent.ACTION_SEND);
 		if (share == true){
 			builder.setTitle(R.string.share_title);
 			builder.setMessage(R.string.share_message);
+	        sharingIntent.setType("text/plain");
+	        sharingIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_WHEN_TASK_RESET);
 		}else{
 			builder.setTitle(R.string.view_title);
 			builder.setMessage(R.string.view_message);
@@ -296,7 +287,10 @@ public class ProfileActivity extends SherlockFragmentActivity implements UserNet
 		    @Override
 		    public void onClick(DialogInterface dialog, int which) {
 		        if (share == true){
-		        	Share(true);
+		        	sharingIntent.putExtra(Intent.EXTRA_TEXT, getResources().getString(R.string.share_animelist)
+		        			.replace("$name;", record.getName())
+		        			.replace("$username;", prefs.getUser()));
+		        	startActivity(Intent.createChooser(sharingIntent, "Share via"));
 		        }else{
 		        	Uri mallisturlanime = Uri.parse("http://myanimelist.net/animelist/" + record.getName());
 	            	startActivity(new Intent(Intent.ACTION_VIEW, mallisturlanime));
@@ -313,7 +307,10 @@ public class ProfileActivity extends SherlockFragmentActivity implements UserNet
 		    @Override
 		    public void onClick(DialogInterface dialog, int which) {
 		    	if (share == true){
-		        	Share(false);
+		    		sharingIntent.putExtra(Intent.EXTRA_TEXT, getResources().getString(R.string.share_mangalist)
+		        			.replace("$name;", record.getName())
+		        			.replace("$username;", prefs.getUser()));
+		    		startActivity(Intent.createChooser(sharingIntent, "Share via"));
 		        }else{
 		        	Uri mallisturlmanga = Uri.parse("http://myanimelist.net/mangalist/" + record.getName());
 	            	startActivity(new Intent(Intent.ACTION_VIEW, mallisturlmanga));


### PR DESCRIPTION
The anime/manga-list share function (profile) broke unexpected.

what I mean with broke...?
R.string.share_mangalist was not returning the string but his id 2131427387.

The same problem was with the animelist share option.
