### PR TITLE
Fix friendlist order on refresh.

### DIFF
--- a/Atarashii/src/net/somethingdreadful/MAL/tasks/FriendsNetworkTask.java
+++ b/Atarashii/src/net/somethingdreadful/MAL/tasks/FriendsNetworkTask.java
@@ -31,11 +31,14 @@ public class FriendsNetworkTask extends AsyncTask<String, Void, ArrayList<User>>
         MALManager mManager = new MALManager(context);
         try {
             if ( forcesync && MALApi.isNetworkAvailable(context) ) {
-                result = mManager.downloadAndStoreFriendList(params[0]);
+                mManager.downloadAndStoreFriendList(params[0]);
+                result = mManager.getFriendListFromDB();
             } else {
                 result = mManager.getFriendListFromDB();
-                if ( ( result == null || result.isEmpty() ) && MALApi.isNetworkAvailable(context) )
-                    result = mManager.downloadAndStoreFriendList(params[0]);
+                if ( ( result == null || result.isEmpty() ) && MALApi.isNetworkAvailable(context) ){
+                    mManager.downloadAndStoreFriendList(params[0]);
+                	result = mManager.getFriendListFromDB();
+                }
             }
 
             /* returning null means there was an error, so return an empty ArrayList if there was no error


### PR DESCRIPTION
The friendlist order got disturbed on every sync.
I modified the code so it will now download and store it into the database and then receive it from the database.
