### PR TITLE
Generate status RadioButtons in status selection dialog from string-array

### DIFF
--- a/Atarashii/res/layout/dialog_status_picker.xml
+++ b/Atarashii/res/layout/dialog_status_picker.xml
@@ -7,52 +7,6 @@
     <RadioGroup
         android:id="@+id/statusRadioGroup"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" >
-
-        <RadioButton
-            android:id="@+id/statusRadio_InProgress"
-            style="@style/Widget.Sherlock.ActionButton"
-            android:layout_width="match_parent"
-            android:layout_height="48dp"
-            android:layout_marginLeft="16dp"
-            android:layout_marginRight="16dp"
-            android:text="@string/listType_InProgress" />
-
-        <RadioButton
-            android:id="@+id/statusRadio_Completed"
-            style="@style/Widget.Sherlock.ActionButton"
-            android:layout_width="match_parent"
-            android:layout_height="48dp"
-            android:layout_marginLeft="16dp"
-            android:layout_marginRight="16dp"
-            android:text="@string/listType_Completed" />
-
-        <RadioButton
-            android:id="@+id/statusRadio_OnHold"
-            style="@style/Widget.Sherlock.ActionButton"
-            android:layout_width="match_parent"
-            android:layout_height="48dp"
-            android:layout_marginLeft="16dp"
-            android:layout_marginRight="16dp"
-            android:text="@string/listType_onhold" />
-
-        <RadioButton
-            android:id="@+id/statusRadio_Dropped"
-            style="@style/Widget.Sherlock.ActionButton"
-            android:layout_width="match_parent"
-            android:layout_height="48dp"
-            android:layout_marginLeft="16dp"
-            android:layout_marginRight="16dp"
-            android:text="@string/listType_dropped" />
-
-        <RadioButton
-            android:id="@+id/statusRadio_Planned"
-            style="@style/Widget.Sherlock.ActionButton"
-            android:layout_width="match_parent"
-            android:layout_height="48dp"
-            android:layout_marginLeft="16dp"
-            android:layout_marginRight="16dp"
-            android:text="@string/listType_planned" />
-    </RadioGroup>
+        android:layout_height="match_parent" />
 
 </ScrollView>

--- a/Atarashii/res/layout/status_radiobutton.xml
+++ b/Atarashii/res/layout/status_radiobutton.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<RadioButton xmlns:android="http://schemas.android.com/apk/res/android"
+    style="@style/Widget.Sherlock.ActionButton"
+    android:layout_width="match_parent"
+    android:layout_height="48dp"
+    android:layout_marginLeft="16dp"
+    android:layout_marginRight="16dp" />

--- a/Atarashii/res/values/ids.xml
+++ b/Atarashii/res/values/ids.xml
@@ -1,4 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:android="http://schemas.android.com/apk/res/android">
     <item type="id" name="notification_sync" />
+    <item type="id" name="statusRadio_Completed" />
+    <item type="id" name="statusRadio_OnHold" />
+    <item type="id" name="statusRadio_Dropped" />
+    <item type="id" name="statusRadio_InProgress" />
+    <item type="id" name="statusRadio_Planned" />
 </resources>

--- a/Atarashii/src/net/somethingdreadful/MAL/StatusPickerDialogFragment.java
+++ b/Atarashii/src/net/somethingdreadful/MAL/StatusPickerDialogFragment.java
@@ -7,11 +7,13 @@ import android.app.AlertDialog;
 import android.app.AlertDialog.Builder;
 import android.app.Dialog;
 import android.content.DialogInterface;
+import android.content.res.Resources;
 import android.os.Bundle;
 import android.view.ContextThemeWrapper;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.RadioButton;
 import android.widget.RadioGroup;
 import com.actionbarsherlock.app.SherlockDialogFragment;
 
@@ -76,6 +78,36 @@ public class StatusPickerDialogFragment extends SherlockDialogFragment {
         }
 
         statusGroup = (RadioGroup) view.findViewById(R.id.statusRadioGroup);
+
+        Resources res = getResources();
+        String[] status = res.getStringArray(R.array.mediaStatus_User);
+
+        // status ids correlated to status strings
+        int[] statusIds = {
+            R.id.statusRadio_Completed,
+            R.id.statusRadio_OnHold,
+            R.id.statusRadio_Dropped,
+            R.id.statusRadio_InProgress,
+            R.id.statusRadio_Planned,
+            R.id.statusRadio_InProgress,
+            R.id.statusRadio_Planned
+        };
+
+        // set button order
+        int[] buttonorder = {
+            ("anime".equals(type) ? 3 : 5),
+            0,
+            1,
+            2,
+            ("anime".equals(type) ? 4 : 6)
+        };
+
+        for (int index: buttonorder) {
+            RadioButton rb = (RadioButton)inflater.inflate(R.layout.status_radiobutton, statusGroup, false);
+            rb.setText(status[index]);
+            rb.setId(statusIds[index]);
+            statusGroup.addView(rb);
+        }
 
         statusGroup.setOnCheckedChangeListener(
                 new RadioGroup.OnCheckedChangeListener() {


### PR DESCRIPTION
This changes StatusPickerDialogFragment to generate the RadioButtons for status selection from the string-array mediaStatus_User. This makes it show the correct status strings: "watching" and "plan to watch" for anime and "reading" and "plan to read" for manga instead of just "in progress" and "planned".

![status_dialog](https://f.cloud.github.com/assets/5774313/2368083/cf875b4e-a795-11e3-900a-e17fcc2125b2.png)
