### PR TITLE
Fix profile image in portrait mode

### DIFF
--- a/Atarashii/res/layout/activity_profile.xml
+++ b/Atarashii/res/layout/activity_profile.xml
@@ -27,6 +27,7 @@
                 android:id="@+id/Image"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:layout_gravity="center_horizontal"
                 android:layout_below="@id/name_card"
                 android:layout_marginLeft="8dp"
                 android:layout_marginRight="8dp"
@@ -42,7 +43,9 @@
 		        android:layout_width="wrap_content"
 		        android:layout_height="wrap_content"
 		        android:layout_gravity="center"
-		        android:paddingBottom="8dp"
+                android:paddingBottom="5dp"
+                android:paddingLeft="10dp"
+                android:paddingRight="10dp"
 		        android:text="@string/layout_card_loading"
 		        android:textColor="#0099CC"
 		        android:textSize="20sp" />


### PR DESCRIPTION
I noticed that the profile image looked different in portrait mode than in landscape mode. This adds the same padding and layout gravity to profile image in portrait mode as in landscape mode. Previously the profile image was not centered, the name had no padding left and right and the bottom padding was different to landscape mode. Now both look similar.
