### PR TITLE
Fix NFC in beta

### DIFF
--- a/Atarashii/src/net/somethingdreadful/MAL/DetailView.java
+++ b/Atarashii/src/net/somethingdreadful/MAL/DetailView.java
@@ -202,7 +202,7 @@ RemoveConfirmationDialogFragment.RemoveConfirmationDialogListener {
                                 "application/net.somethingdreadful.MAL".getBytes(Charset.forName("US-ASCII")),
                                 new byte[0], message_str.getBytes(Charset.forName("US-ASCII"))
                                 ),
-                                NdefRecord.createApplicationRecord("net.somethingdreadful.MAL")
+                                NdefRecord.createApplicationRecord(getPackageName())
                 });
                 mNfcAdapter.setNdefPushMessage(message, this);
             }


### PR DESCRIPTION
NFC is not working in the beta because of the different package name: the NFC-record is for the package _net.somethingdreadful.MAL_, but the beta is _net.somethingdreadful.MAL.**beta**_ so the play store opens on the target device.
I changed setupBeam() to use the real package name instead of a hardcoded one.
