### PR TITLE
Change API URL to use https

### DIFF
--- a/Atarashii/src/net/somethingdreadful/MAL/api/MALApi.java
+++ b/Atarashii/src/net/somethingdreadful/MAL/api/MALApi.java
@@ -27,7 +27,7 @@ import android.os.Build;
 import android.util.Log;
 
 public class MALApi {
-    private static final String API_HOST = "http://newapi.atarashiiapp.com";
+    private static final String API_HOST = "https://newapi.atarashiiapp.com";
     private static final String USER_AGENT = "Atarashii! (Linux; Android " + Build.VERSION.RELEASE + "; " + Build.MODEL + " Build/" + Build.DISPLAY + ")";
     
     private MALInterface service;


### PR DESCRIPTION
@motokochan enabled SSL for the new API with a valid certificate (thanks! :+1: ), so we should use it (fixes #137). I tested with Android 4.4.2 and Android 2.2 and both accepted the certificate and everything is working.
