### PR TITLE
Fix friendlist bug (showing twice an user & hiding an user).

### DIFF
--- a/Atarashii/src/net/somethingdreadful/MAL/sql/DatabaseManager.java
+++ b/Atarashii/src/net/somethingdreadful/MAL/sql/DatabaseManager.java
@@ -254,6 +254,7 @@ public class DatabaseManager {
     public void saveFriendList(ArrayList<User> list) {
         if ( list != null && list.size() > 0 ) {
             try {
+            	getDBWrite().delete(MALSqlHelper.TABLE_FRIENDS, null, new String[]{});
                 getDBWrite().beginTransaction();
                 for(User friend: list)
                     saveFriend(friend);


### PR DESCRIPTION
Because we didn't added a method that removed the old friend records it was being overwritten.
This was the cause of an user that has been shown twice or hidden users.

This fix clears the table when we fletched the details & we're about to save it into the database.
