### PR TITLE
Link customShareText with the String.xml file for the translations.

### DIFF
--- a/Atarashii/src/net/somethingdreadful/MAL/PrefManager.java
+++ b/Atarashii/src/net/somethingdreadful/MAL/PrefManager.java
@@ -24,7 +24,7 @@ public class PrefManager {
     }
 
     public String getCustomShareText() {
-        return prefs.getString("customShareText", "Check out $title; on MyAnimeList!\n$link;");
+        return prefs.getString("customShareText", context.getString(R.string.preference_default_customShareText));
     }
 
     public boolean getUpgradeInit() {


### PR DESCRIPTION
The translations (string.xml) wasn't linked with the prefmanager.
In this commit I removed the hardcoded string and linked it with the strings.xml file.
