### PR TITLE
Fix time display format

### DIFF
--- a/Atarashii/res/values/strings.xml
+++ b/Atarashii/res/values/strings.xml
@@ -326,9 +326,9 @@
     </string-array>
 
     <string name="dateformat">MM-dd-yy</string>
-    <string name="datetimeformat">MM-dd-yy, h:m a</string>
-    <string name="datetimeformat_yesterday">\'Yesterday\', h:m a</string>
-    <string name="datetimeformat_dayname">EEEE, h:m a</string>
+    <string name="datetimeformat">MM-dd-yy, h:mm a</string>
+    <string name="datetimeformat_yesterday">\'Yesterday\', h:mm a</string>
+    <string name="datetimeformat_dayname">EEEE, h:mm a</string>
     <plurals name="minutes_ago">
         <item quantity="zero">now</item>
         <item quantity="one">One minute ago</item>


### PR DESCRIPTION
Single digit minutes were displayed without leading zero (e. g. 6:09 was displayed as 6:9).
