### PR TITLE
Remove some hardcoded strings in DetailView

### DIFF
--- a/Atarashii/res/layout-land/card_layout_content_synopsis.xml
+++ b/Atarashii/res/layout-land/card_layout_content_synopsis.xml
@@ -8,7 +8,7 @@
         style="@style/TextViewLightFont"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:text="Loading, just a sec." >
+        android:text="@string/card_content_loading" >
     </TextView>
 
 </ScrollView>

--- a/Atarashii/res/layout/card_layout_content_synopsis.xml
+++ b/Atarashii/res/layout/card_layout_content_synopsis.xml
@@ -8,7 +8,7 @@
         style="@style/TextViewLightFont"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:text="Loading, just a sec." >
+        android:text="@string/card_content_loading" >
     </TextView>
 
 </LinearLayout>

--- a/Atarashii/res/layout/card_layout_watchstatus.xml
+++ b/Atarashii/res/layout/card_layout_watchstatus.xml
@@ -8,7 +8,7 @@
         style="@style/TextViewLightFont"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:text="Reading"
+        android:text="@string/card_content_loading"
         android:textSize="28sp" />
 
 </LinearLayout>

--- a/Atarashii/res/values/strings.xml
+++ b/Atarashii/res/values/strings.xml
@@ -150,6 +150,7 @@
     <string name="card_content_my_score">My Score</string>
     <string name="card_content_media_type">Media Type</string>
     <string name="card_content_media_status">Media Status</string>
+    <string name="card_content_loading">Loading, just a sec.</string>
 
     <!-- DetailView (Actionbar actions) Strings -->
     <string name="action_viewMALPage">View Details on MyAnimeList</string>


### PR DESCRIPTION
This removes some hardcoded strings displayed while data loading (in synopsis and status card).
