### PR TITLE
Bugfix: prevent entries without status in anime/manga list

### DIFF
--- a/Atarashii/src/net/somethingdreadful/MAL/MALManager.java
+++ b/Atarashii/src/net/somethingdreadful/MAL/MALManager.java
@@ -155,7 +155,9 @@ public class MALManager {
     	if ( anime_api != null ) {
     		anime.setSynopsis(anime_api.getSynopsis());
     		anime.setMembersScore(anime_api.getMembersScore());
-            dbMan.saveAnime(anime, false);
+            // only store anime with user status in database
+            if (anime.getWatchedStatus() != null)
+                dbMan.saveAnime(anime, false);
     	}
         
         return anime;
@@ -214,7 +216,9 @@ public class MALManager {
     	if ( manga_api != null ) {
     		manga.setSynopsis(manga_api.getSynopsis());
     		manga.setMembersScore(manga_api.getMembersScore());
-    		dbMan.saveManga(manga, false);
+            // only store manga with user status in database
+            if (manga.getReadStatus() != null)
+    		    dbMan.saveManga(manga, false);
     	}
         
         return manga;


### PR DESCRIPTION
This should fix #161. Entries were saved to the database even if they have no watch/read status. That caused them to show up in the users anime/manga list if the filter was set to show all.

Maybe related fix: Also removed an useless setCreateFlag() as it does not make sense to set the create flag to an entry without read/watch status (the create flag is used to determine if a create request must be sent to the API, which is useless without read/watch status).
