### PR TITLE
Gradle configuration update for Android Studio >= 0.6

### DIFF
--- a/Atarashii/build.gradle
+++ b/Atarashii/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'android'
 
 android {
     compileSdkVersion 19
-    buildToolsVersion "19.0.1"
+    buildToolsVersion "19.1.0"
 
     defaultConfig {
         minSdkVersion 8
@@ -45,6 +45,9 @@ repositories {
     maven {
         url 'https://github.com/toxbee/mvn-repo/raw/master/maven-deploy'
     }
+    maven {
+        url 'https://raw.github.com/nicolasjafelle/maven-repo/master/'
+    }
 }
 
 dependencies {
@@ -56,5 +59,5 @@ dependencies {
     compile 'com.squareup.retrofit:retrofit:1.4.1'
     compile 'org.apache.commons:commons-lang3:3.2.1'
     compile 'com.squareup.picasso:picasso:2.2.0'
-    compile project(':sherlocknavdrawer')
+    compile 'com.sherlock:navigationdrawer:+@aar'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.10.+'
+        classpath 'com.android.tools.build:gradle:0.11.+'
     }
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,1 @@
 include ':Atarashii'
-include ':sherlocknavdrawer'
-
-project(':sherlocknavdrawer').projectDir = new File(rootDir, '/third-party/SherlockNavDrawer/SherlockNavigationDrawer')


### PR DESCRIPTION
This makes the gradle configuration compatible to Android Studio 0.6.
Also every dependency is loaded from maven repos now, SherlockNavDrawer was the last one that was not fetched from maven but I noticed that the author has a repo for this so I updated the configuration.
This was necessary because the gradle config in the SherlockNavDrawer submodule was not compatible to Android Studio >= 0.6.
