### PR TITLE
Unify Anime/MangaNetworkTask callback interface

### DIFF
--- a/Atarashii/src/net/somethingdreadful/MAL/SearchActivity.java
+++ b/Atarashii/src/net/somethingdreadful/MAL/SearchActivity.java
@@ -176,7 +176,7 @@ public class SearchActivity extends Activity implements TabListener, ViewPager.O
     public void onPause() {
         super.onPause();
     }
-	
+
 	public static void onError(ListType type, boolean error, Activity activity, TaskJob job) {
 		called = called + 1;
 		

--- a/Atarashii/src/net/somethingdreadful/MAL/tasks/AnimeNetworkTask.java
+++ b/Atarashii/src/net/somethingdreadful/MAL/tasks/AnimeNetworkTask.java
@@ -3,6 +3,7 @@ package net.somethingdreadful.MAL.tasks;
 import java.util.ArrayList;
 
 import net.somethingdreadful.MAL.MALManager;
+import net.somethingdreadful.MAL.api.MALApi;
 import net.somethingdreadful.MAL.api.response.Anime;
 import android.content.Context;
 import android.os.AsyncTask;
@@ -12,17 +13,17 @@ public class AnimeNetworkTask extends AsyncTask<String, Void, ArrayList<Anime>> 
 	TaskJob job;
 	int page = 1;
 	Context context;
-	Anime record;
-	AnimeNetworkTaskFinishedListener callback;
+    Anime record;
+    NetworkTaskCallbackListener callback;
 	
-	public AnimeNetworkTask(TaskJob job, int page, Context context, AnimeNetworkTaskFinishedListener callback) {
+	public AnimeNetworkTask(TaskJob job, int page, Context context, NetworkTaskCallbackListener callback) {
 		this.job = job;
 		this.page = page;
 		this.context = context;
 		this.callback = callback;
 	}
 
-	public AnimeNetworkTask(TaskJob job, Context context, Anime anime, AnimeNetworkTaskFinishedListener callback) {
+	public AnimeNetworkTask(TaskJob job, Context context, Anime anime, NetworkTaskCallbackListener callback) {
 		this.job = job;
 		this.context = context;
 		this.record = anime;
@@ -98,6 +99,6 @@ public class AnimeNetworkTask extends AsyncTask<String, Void, ArrayList<Anime>> 
 	@Override
 	protected void onPostExecute(ArrayList<Anime> result) {
 		if (callback != null)
-			callback.onAnimeNetworkTaskFinished(result, job, page);
+			callback.onNetworkTaskFinished(result, job, page, MALApi.ListType.ANIME);
 	}
 }

--- a/Atarashii/src/net/somethingdreadful/MAL/tasks/AnimeNetworkTaskFinishedListener.java
+++ b/Atarashii/src/net/somethingdreadful/MAL/tasks/AnimeNetworkTaskFinishedListener.java
@@ -1,9 +1,0 @@
-package net.somethingdreadful.MAL.tasks;
-
-import java.util.ArrayList;
-
-import net.somethingdreadful.MAL.api.response.Anime;
-
-public interface AnimeNetworkTaskFinishedListener {
-	public void onAnimeNetworkTaskFinished(ArrayList<Anime> result, TaskJob job, int page);
-}

--- a/Atarashii/src/net/somethingdreadful/MAL/tasks/MangaNetworkTask.java
+++ b/Atarashii/src/net/somethingdreadful/MAL/tasks/MangaNetworkTask.java
@@ -3,6 +3,7 @@ package net.somethingdreadful.MAL.tasks;
 import java.util.ArrayList;
 
 import net.somethingdreadful.MAL.MALManager;
+import net.somethingdreadful.MAL.api.MALApi;
 import net.somethingdreadful.MAL.api.response.Manga;
 import android.content.Context;
 import android.os.AsyncTask;
@@ -12,17 +13,17 @@ public class MangaNetworkTask extends AsyncTask<String, Void, ArrayList<Manga>> 
 	TaskJob job;
 	int page = 1;
 	Context context;
-	Manga record;
-	MangaNetworkTaskFinishedListener callback;
+    Manga record;
+	NetworkTaskCallbackListener callback;
 
-	public MangaNetworkTask(TaskJob job, int page, Context context, MangaNetworkTaskFinishedListener callback) {
+	public MangaNetworkTask(TaskJob job, int page, Context context, NetworkTaskCallbackListener callback) {
 		this.job = job;
 		this.page = page;
 		this.context = context;
 		this.callback = callback;
 	}
 	
-	public MangaNetworkTask(TaskJob job, Context context, Manga manga, MangaNetworkTaskFinishedListener callback) {
+	public MangaNetworkTask(TaskJob job, Context context, Manga manga, NetworkTaskCallbackListener callback) {
 		this.job = job;
 		this.context = context;
 		this.callback = callback;
@@ -97,6 +98,6 @@ public class MangaNetworkTask extends AsyncTask<String, Void, ArrayList<Manga>> 
 	@Override
 	protected void onPostExecute(ArrayList<Manga> result) {
 		if (callback != null)
-			callback.onMangaNetworkTaskFinished(result, job, page);
+			callback.onNetworkTaskFinished(result, job, page, MALApi.ListType.MANGA);
 	}
 }

--- a/Atarashii/src/net/somethingdreadful/MAL/tasks/MangaNetworkTaskFinishedListener.java
+++ b/Atarashii/src/net/somethingdreadful/MAL/tasks/MangaNetworkTaskFinishedListener.java
@@ -1,9 +1,0 @@
-package net.somethingdreadful.MAL.tasks;
-
-import java.util.ArrayList;
-
-import net.somethingdreadful.MAL.api.response.Manga;
-
-public interface MangaNetworkTaskFinishedListener {
-	public void onMangaNetworkTaskFinished(ArrayList<Manga> result, TaskJob job, int page);
-}

--- a/Atarashii/src/net/somethingdreadful/MAL/tasks/NetworkTaskCallbackListener.java
+++ b/Atarashii/src/net/somethingdreadful/MAL/tasks/NetworkTaskCallbackListener.java
@@ -1,0 +1,9 @@
+package net.somethingdreadful.MAL.tasks;
+
+import net.somethingdreadful.MAL.api.MALApi;
+
+import java.util.ArrayList;
+
+public interface NetworkTaskCallbackListener {
+    public void onNetworkTaskFinished(Object result, TaskJob job, int page, MALApi.ListType type);
+}


### PR DESCRIPTION
While working on something different I noticed that the callback functions for AnimeNetworkTask and MangaNetworkTask always contain the same logic except for the result type (Anime/Manga). This means there is many duplicated code. I unified the callback to simplify this.
Now classes (ItemGridFragment and SearchActivity) have to implement only one interface with one callback function instead of two. Separation between Anime and Manga is possible by using the callback's _ListType_ parameter _type_.

I've tested this compared to 1.4 RC2 and noticed no differences, everything just works like before.
