### PR TITLE
Fix isAdded() method on refresh by requesting more details (DetailView)

### DIFF
--- a/Atarashii/src/net/somethingdreadful/MAL/api/MALInterface.java
+++ b/Atarashii/src/net/somethingdreadful/MAL/api/MALInterface.java
@@ -23,7 +23,7 @@ public interface MALInterface {
     @GET("/account/verify_credentials")
     Response verifyAuthentication();
 
-    @GET("/anime/{anime_id}")
+    @GET("/anime/{anime_id}?mine=1")
     Anime getAnime(@Path("anime_id") int anime_id);
 
     @GET("/anime/search")
@@ -57,7 +57,7 @@ public interface MALInterface {
     Response updateAnime(@Path("anime_id") int id, @Field("status") String status, @Field("episodes") int episodes,
                          @Field("score") int score);
 
-    @GET("/manga/{manga_id}")
+    @GET("/manga/{manga_id}?mine=1")
     Manga getManga(@Path("manga_id") int manga_id);
 
     @GET("/manga/search")


### PR DESCRIPTION
When refreshing the DetailView the isAdded method doesn't work because we aren't receiving the necessary details from the API to determine if we added the anime in out list.

We could get the records again from the database but it would be better if we just request more details because of the extended features which we will introduce soon.
