### PR TITLE
Show loading indicator while downloading additional data (DetailView)

### DIFF
--- a/Atarashii/src/net/somethingdreadful/MAL/DetailView.java
+++ b/Atarashii/src/net/somethingdreadful/MAL/DetailView.java
@@ -524,6 +524,7 @@ public class DetailView extends Activity implements Serializable, OnRatingBarCha
             if (MALApi.isNetworkAvailable(context)) {
                 Bundle data = new Bundle();
                 data.putSerializable("record", type.equals(ListType.ANIME) ? animeRecord : mangaRecord);
+                swipeRefresh.setRefreshing(true);
                 new NetworkTask(TaskJob.GETDETAILS, type, context, data, this, this).execute();
             } else {
                 synopsis.setText(getString(R.string.crouton_error_noConnectivity));


### PR DESCRIPTION
This PR will enable the loading indicator when Atarashii is downloading additional data like the synopsis.
