### PR TITLE
Fix crash on pressing back after DV is done with loading (DetailView)

### DIFF
--- a/Atarashii/src/net/somethingdreadful/MAL/DetailView.java
+++ b/Atarashii/src/net/somethingdreadful/MAL/DetailView.java
@@ -401,23 +401,27 @@ public class DetailView extends Activity implements Serializable, OnRatingBarCha
 
     @TargetApi(Build.VERSION_CODES.ICE_CREAM_SANDWICH)
     private void setupBeam() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH) {
-            // setup beam functionality (if NFC is available)
-            NfcAdapter mNfcAdapter = NfcAdapter.getDefaultAdapter(this);
-            if (mNfcAdapter == null) {
-                Log.i("MALX", "NFC not available");
-            } else {
-                // Register NFC callback
-                String message_str = type.toString() + ":" + String.valueOf(recordID);
-                NdefMessage message = new NdefMessage(new NdefRecord[]{
-                        new NdefRecord(
-                                NdefRecord.TNF_MIME_MEDIA,
-                                "application/net.somethingdreadful.MAL".getBytes(Charset.forName("US-ASCII")),
-                                new byte[0], message_str.getBytes(Charset.forName("US-ASCII"))),
-                        NdefRecord.createApplicationRecord(getPackageName())
-                });
-                mNfcAdapter.setNdefPushMessage(message, this);
+        try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH) {
+                // setup beam functionality (if NFC is available)
+                NfcAdapter mNfcAdapter = NfcAdapter.getDefaultAdapter(this);
+                if (mNfcAdapter == null) {
+                    Log.i("MALX", "NFC not available");
+                } else {
+                    // Register NFC callback
+                    String message_str = type.toString() + ":" + String.valueOf(recordID);
+                    NdefMessage message = new NdefMessage(new NdefRecord[]{
+                            new NdefRecord(
+                                    NdefRecord.TNF_MIME_MEDIA,
+                                    "application/net.somethingdreadful.MAL".getBytes(Charset.forName("US-ASCII")),
+                                    new byte[0], message_str.getBytes(Charset.forName("US-ASCII"))),
+                            NdefRecord.createApplicationRecord(getPackageName())
+                    });
+                    mNfcAdapter.setNdefPushMessage(message, this);
+                }
             }
+        } catch (Exception e) {
+            Log.e("MALX", "error at setupBeam: " + e.getMessage());
         }
     }
 


### PR DESCRIPTION
The Detailview was crashing when I pressed back while the app was loading the additional details.
Apparently is was because the activity was destroyed while setupbeam was called.

I just added a try block to catch the Exception that caused the crash.
