### PR TITLE
Fix show dialog when pressing next to Textview (Card)

### DIFF
--- a/Atarashii/res/layout/card_detailview_status.xml
+++ b/Atarashii/res/layout/card_detailview_status.xml
@@ -1,6 +1,6 @@
 <TextView xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/cardStatusLabel"
-    android:layout_width="wrap_content"
+    android:layout_width="fill_parent"
     android:layout_height="wrap_content"
     android:text="@string/card_content_loading"
     android:textAppearance="?android:attr/textAppearanceLarge" />


### PR DESCRIPTION
When you press next to the status textview (in the card) the dialog won't show up. This PR will fix it.

I simply changed wrap content into fill to fill the textview.
