### PR TITLE
Fix text outside the card shadow (Card)

### DIFF
--- a/Atarashii/res/layout/card_layout_base.xml
+++ b/Atarashii/res/layout/card_layout_base.xml
@@ -26,7 +26,8 @@
     <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_below="@id/CardTitle">
+        android:layout_below="@id/CardTitle"
+        android:paddingBottom="1dp">
 
         <RelativeLayout
             android:id="@+id/content"


### PR DESCRIPTION
If the text doesn't fit in the screen the card will automatically show a scrollbar for scrolling. 

The shadow is within the cardview so it has a limit just like the scrollview. Both of them were using the same limit causing the text appearing above the shadow.

I added a scrollview limit by using a padding of 1dp which won't be above the shadow.
