### PR TITLE
Fix the header margin after removing HEW (Cards)

### DIFF
--- a/Atarashii/res/layout/card_layout_base.xml
+++ b/Atarashii/res/layout/card_layout_base.xml
@@ -4,7 +4,8 @@
     android:id="@+id/BaseCard"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    card_view:cardCornerRadius="2dp">
+    card_view:cardCornerRadius="2dp"
+    card_view:cardPreventCornerOverlap="false" >
 
     <RelativeLayout
         android:layout_width="wrap_content"


### PR DESCRIPTION
There was a padding problem after dropping HEW. 

Apparently HEW wasn't supporting the corner overlay system which caused to disable it. So as soon we removed HEW the corner overlay system began to work...
