### PR TITLE
Remove the capital R which caused spacing problems (Strings)

### DIFF
--- a/Atarashii/res/values/strings.xml
+++ b/Atarashii/res/values/strings.xml
@@ -264,7 +264,7 @@
     <string name="contributor_apkawa_summary">Implemented search functionality. </string>
     <string name="contributor_dsko_name">Dustin Skoracki (<a href="http://myanimelist.net/profile/d-sko">d-sko</a>)</string>
     <string name="contributor_dsko_summary">Implemented retrofit for API handling.</string>
-    <string name="contributor_ratan12_name">Ratan Dhawtal (<a href="http://myanimelist.net/profile/ratan12">Ratan12</a>)</string>
+    <string name="contributor_ratan12_name">Ratan Dhawtal (<a href="http://myanimelist.net/profile/ratan12">ratan12</a>)</string>
     <string name="contributor_ratan12_summary">Managing all translations, creating new features and working on the UI.</string>
     <string name="translations">Atarashii! started to support different languages since version 1.4! Everyone can <a href="http://atarashii.oneskyapp.com/collaboration/project?id=22217">join the translation project</a> to contribute.</string>
     <string name="translations_notListed">My language is not listed on oneskyapp?</string>


### PR DESCRIPTION
I don't know why but the new theme was adding an space before my name which made the design inconsistent. I replaced it with 'r' which is the real first character of my MAL account.
