### PR TITLE
Gradle update for Android Studio 1.0

### DIFF
--- a/Atarashii/build.gradle
+++ b/Atarashii/build.gradle
@@ -23,13 +23,6 @@ android {
         targetSdkVersion 21
     }
 
-    buildTypes {
-        release {
-            runProguard false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
-        }
-    }
-
     sourceSets {
         main {
             manifest {

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.12.+'
+        classpath 'com.android.tools.build:gradle:1.0.0-rc2'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu May 08 22:46:56 CEST 2014
+#Fri Dec 05 13:25:21 CET 2014
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.12-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip


### PR DESCRIPTION
This updates the gradle configuration to support AS 1.0. It also removes the proguard config as runProguard is not longer available (is now "minifyEnabled") and it was disabled anyway.
