### PR TITLE
Show load indicator even if we pass the user record (Profile)

### DIFF
--- a/Atarashii/src/net/somethingdreadful/MAL/ProfileActivity.java
+++ b/Atarashii/src/net/somethingdreadful/MAL/ProfileActivity.java
@@ -75,6 +75,7 @@ public class ProfileActivity extends ActionBarActivity implements UserNetworkTas
         swipeRefresh.setEnabled(true);
 
         if (getIntent().getExtras().containsKey("user")) {
+            toggle(1);
             record = (User) getIntent().getExtras().get("user");
             refresh();
         } else {


### PR DESCRIPTION
In the past we were showing the loading indicator with the network card which is kinda ugly XD
