### PR TITLE
Fix messed up episode/volume counter when preceding text is wrapped

### DIFF
--- a/Atarashii/res/layout/record_igf_panel.xml
+++ b/Atarashii/res/layout/record_igf_panel.xml
@@ -21,7 +21,7 @@
     <LinearLayout
         android:layout_width="fill_parent"
         android:layout_height="match_parent"
-        android:baselineAlignedChildIndex="2"
+        android:baselineAligned="false"
         android:clipChildren="false"
         android:orientation="horizontal">
 


### PR DESCRIPTION
This fixes the displaying of the episode/volume counter on some DPI/resolution configurations where the preceding text is wrapped.
