### PR TITLE
Fix the search button that wasn't working (Home)

### DIFF
--- a/Atarashii/src/net/somethingdreadful/MAL/Home.java
+++ b/Atarashii/src/net/somethingdreadful/MAL/Home.java
@@ -7,6 +7,7 @@ import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.app.SearchManager;
 import android.content.BroadcastReceiver;
+import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
@@ -142,7 +143,8 @@ public class Home extends ActionBarActivity implements SwipeRefreshLayout.OnRefr
         SearchManager searchManager = (SearchManager) getSystemService(Context.SEARCH_SERVICE);
         MenuItem searchItem = menu.findItem(R.id.action_search);
         SearchView searchView = (SearchView) MenuItemCompat.getActionView(searchItem);
-        searchView.setSearchableInfo(searchManager.getSearchableInfo(getComponentName()));
+        ComponentName cn = new ComponentName(this, SearchActivity.class);
+        searchView.setSearchableInfo(searchManager.getSearchableInfo(cn));
         return true;
     }
 


### PR DESCRIPTION
The search button wasn't working because we were using getComponentName() that would get the Home component name instead the searchActivity.

Why it was working on the alpha builds will remain a mystery XD

Fixes #296
