### PR TITLE
Fix numberpickers don't lose focus after a manually input (src)

### DIFF
--- a/Atarashii/src/net/somethingdreadful/MAL/dialog/EpisodesPickerDialogFragment.java
+++ b/Atarashii/src/net/somethingdreadful/MAL/dialog/EpisodesPickerDialogFragment.java
@@ -39,6 +39,7 @@ public class EpisodesPickerDialogFragment extends DialogFragment {
         builder.setPositiveButton(R.string.dialog_label_update, new DialogInterface.OnClickListener() {
             @Override
             public void onClick(DialogInterface dialog, int whichButton) {
+                numberPicker.clearFocus();
                 ((DetailView) getActivity()).onDialogDismissed(numberPicker.getValue());
                 dismiss();
             }

--- a/Atarashii/src/net/somethingdreadful/MAL/dialog/MangaPickerDialogFragment.java
+++ b/Atarashii/src/net/somethingdreadful/MAL/dialog/MangaPickerDialogFragment.java
@@ -58,6 +58,8 @@ public class MangaPickerDialogFragment extends DialogFragment {
         builder.setPositiveButton(R.string.dialog_label_update, new DialogInterface.OnClickListener() {
             @Override
             public void onClick(DialogInterface dialog, int whichButton) {
+                chapterPicker.clearFocus();
+                volumePicker.clearFocus();
                 ((DetailView) getActivity()).onMangaDialogDismissed(chapterPicker.getValue(), volumePicker.getValue());
                 dismiss();
             }


### PR DESCRIPTION
The numberpickers weren't updating the manually input because it was still focused.

Fixes #305 
