### PR TITLE
Fix for setDirty(true) being always called in DetailViewGeneral

### DIFF
--- a/Atarashii/src/net/somethingdreadful/MAL/DetailViewGeneral.java
+++ b/Atarashii/src/net/somethingdreadful/MAL/DetailViewGeneral.java
@@ -274,15 +274,17 @@ public class DetailViewGeneral extends Fragment implements Serializable, OnRatin
 
     @Override
     public void onRatingChanged(RatingBar ratingBar, float rating, boolean fromUser) {
-        if (activity.type.equals(ListType.ANIME)) {
-            if (activity.animeRecord != null) {
-                activity.animeRecord.setScore((int) (rating * 2));
-                activity.animeRecord.setDirty(true);
-            }
-        } else {
-            if (activity.mangaRecord != null) {
-                activity.mangaRecord.setScore((int) (rating * 2));
-                activity.mangaRecord.setDirty(true);
+        if (fromUser) {
+            if (activity.type.equals(ListType.ANIME)) {
+                if (activity.animeRecord != null) {
+                    activity.animeRecord.setScore((int) (rating * 2));
+                    activity.animeRecord.setDirty(true);
+                }
+            } else {
+                if (activity.mangaRecord != null) {
+                    activity.mangaRecord.setScore((int) (rating * 2));
+                    activity.mangaRecord.setDirty(true);
+                }
             }
         }
     }


### PR DESCRIPTION
Because fromUser was not checked in the onRatingChanged()-callback the code was always executed, not only if the rating was changed by the user. This means the record was always flagged as dirty (which caused unneccessary API requests), because this callback is also called if the value is changed programmatically.
