### PR TITLE
Dirty flag rewrite

### DIFF
--- a/Atarashii/src/net/somethingdreadful/MAL/DetailView.java
+++ b/Atarashii/src/net/somethingdreadful/MAL/DetailView.java
@@ -589,13 +589,13 @@ public class DetailView extends ActionBarActivity implements Serializable, Netwo
 
         try {
             if (type.equals(ListType.ANIME)) {
-                if (!animeRecord.getDirty().isEmpty() && !animeRecord.getDeleteFlag()) {
+                if (!animeRecord.isDirty() && !animeRecord.getDeleteFlag()) {
                     new WriteDetailTask(type, TaskJob.UPDATE, this, this).execute(animeRecord);
                 } else if (animeRecord.getDeleteFlag()) {
                     new WriteDetailTask(type, TaskJob.FORCESYNC, this, this).execute(animeRecord);
                 }
             } else if (type.equals(ListType.MANGA)) {
-                if (!mangaRecord.getDirty().isEmpty() && !mangaRecord.getDeleteFlag()) {
+                if (!mangaRecord.isDirty() && !mangaRecord.getDeleteFlag()) {
                     new WriteDetailTask(type, TaskJob.UPDATE, this, this).execute(mangaRecord);
                 } else if (mangaRecord.getDeleteFlag()) {
                     new WriteDetailTask(type, TaskJob.FORCESYNC, this, this).execute(mangaRecord);

--- a/Atarashii/src/net/somethingdreadful/MAL/DetailView.java
+++ b/Atarashii/src/net/somethingdreadful/MAL/DetailView.java
@@ -589,13 +589,13 @@ public class DetailView extends ActionBarActivity implements Serializable, Netwo
 
         try {
             if (type.equals(ListType.ANIME)) {
-                if (!animeRecord.isDirty() && !animeRecord.getDeleteFlag()) {
+                if (animeRecord.isDirty() && !animeRecord.getDeleteFlag()) {
                     new WriteDetailTask(type, TaskJob.UPDATE, this, this).execute(animeRecord);
                 } else if (animeRecord.getDeleteFlag()) {
                     new WriteDetailTask(type, TaskJob.FORCESYNC, this, this).execute(animeRecord);
                 }
             } else if (type.equals(ListType.MANGA)) {
-                if (!mangaRecord.isDirty() && !mangaRecord.getDeleteFlag()) {
+                if (mangaRecord.isDirty() && !mangaRecord.getDeleteFlag()) {
                     new WriteDetailTask(type, TaskJob.UPDATE, this, this).execute(mangaRecord);
                 } else if (mangaRecord.getDeleteFlag()) {
                     new WriteDetailTask(type, TaskJob.FORCESYNC, this, this).execute(mangaRecord);

--- a/Atarashii/src/net/somethingdreadful/MAL/DetailView.java
+++ b/Atarashii/src/net/somethingdreadful/MAL/DetailView.java
@@ -238,10 +238,6 @@ public class DetailView extends ActionBarActivity implements Serializable, Netwo
                     mangaRecord.setRereadCount(number);
                 break;
         }
-        if (isAnime())
-            animeRecord.setDirty(true);
-        else
-            mangaRecord.setDirty(true);
         setText();
     }
 
@@ -264,10 +260,6 @@ public class DetailView extends ActionBarActivity implements Serializable, Netwo
                 animeRecord.setFansubGroup(message);
                 break;
         }
-        if (isAnime())
-            animeRecord.setDirty(true);
-        else
-            mangaRecord.setDirty(true);
         setText();
     }
 
@@ -287,13 +279,11 @@ public class DetailView extends ActionBarActivity implements Serializable, Netwo
                 animeRecord.setWatchingStart(Integer.toString(year) + "-" + monthString + "-" + dayString);
             else
                 animeRecord.setWatchingEnd(Integer.toString(year) + "-" + monthString + "-" + dayString);
-            animeRecord.setDirty(true);
         } else {
             if (startDate)
                 mangaRecord.setReadingStart(Integer.toString(year) + "-" + monthString + "-" + dayString);
             else
                 mangaRecord.setReadingEnd(Integer.toString(year) + "-" + monthString + "-" + dayString);
-            mangaRecord.setDirty(true);
         }
         setText();
     }
@@ -327,11 +317,9 @@ public class DetailView extends ActionBarActivity implements Serializable, Netwo
             if (type.equals(ListType.ANIME)) {
                 animeRecord.setCreateFlag(true);
                 animeRecord.setWatchedStatus(Anime.STATUS_WATCHING);
-                animeRecord.setDirty(true);
             } else {
                 mangaRecord.setCreateFlag(true);
                 mangaRecord.setReadStatus(Manga.STATUS_READING);
-                mangaRecord.setDirty(true);
             }
             setText();
         }
@@ -493,7 +481,6 @@ public class DetailView extends ActionBarActivity implements Serializable, Netwo
                 if (animeRecord.getEpisodes() != 0)
                     animeRecord.setWatchedEpisodes(animeRecord.getEpisodes());
             }
-            animeRecord.setDirty(true);
         } else {
             mangaRecord.setReadStatus(currentStatus);
             if (GenericRecord.STATUS_COMPLETED.equals(currentStatus)) {
@@ -502,7 +489,6 @@ public class DetailView extends ActionBarActivity implements Serializable, Netwo
                 if (mangaRecord.getVolumes() != 0)
                     mangaRecord.setVolumesRead(mangaRecord.getVolumes());
             }
-            mangaRecord.setDirty(true);
         }
         setText();
     }
@@ -517,7 +503,6 @@ public class DetailView extends ActionBarActivity implements Serializable, Netwo
                 mangaRecord.setReadStatus(Manga.STATUS_PLANTOREAD);
             }
             mangaRecord.setChaptersRead(value);
-            mangaRecord.setDirty(true);
         }
 
         if (value2 != mangaRecord.getVolumesRead()) {
@@ -528,7 +513,6 @@ public class DetailView extends ActionBarActivity implements Serializable, Netwo
                 mangaRecord.setReadStatus(Manga.STATUS_PLANTOREAD);
             }
             mangaRecord.setVolumesRead(value2);
-            mangaRecord.setDirty(true);
         }
 
         setText();
@@ -537,10 +521,8 @@ public class DetailView extends ActionBarActivity implements Serializable, Netwo
 
     public void onRemoveConfirmed() {
         if (type.equals(ListType.ANIME)) {
-            animeRecord.setDirty(true);
             animeRecord.setDeleteFlag(true);
         } else {
-            mangaRecord.setDirty(true);
             mangaRecord.setDeleteFlag(true);
         }
         finish();
@@ -607,13 +589,13 @@ public class DetailView extends ActionBarActivity implements Serializable, Netwo
 
         try {
             if (type.equals(ListType.ANIME)) {
-                if (animeRecord.getDirty() && !animeRecord.getDeleteFlag()) {
+                if (!animeRecord.getDirty().isEmpty() && !animeRecord.getDeleteFlag()) {
                     new WriteDetailTask(type, TaskJob.UPDATE, this, this).execute(animeRecord);
                 } else if (animeRecord.getDeleteFlag()) {
                     new WriteDetailTask(type, TaskJob.FORCESYNC, this, this).execute(animeRecord);
                 }
             } else if (type.equals(ListType.MANGA)) {
-                if (mangaRecord.getDirty() && !mangaRecord.getDeleteFlag()) {
+                if (!mangaRecord.getDirty().isEmpty() && !mangaRecord.getDeleteFlag()) {
                     new WriteDetailTask(type, TaskJob.UPDATE, this, this).execute(mangaRecord);
                 } else if (mangaRecord.getDeleteFlag()) {
                     new WriteDetailTask(type, TaskJob.FORCESYNC, this, this).execute(mangaRecord);
@@ -681,12 +663,8 @@ public class DetailView extends ActionBarActivity implements Serializable, Netwo
         try {
             if (type == ListType.ANIME) {
                 animeRecord = (Anime) result;
-                if (isAdded() && AccountService.isMAL())
-                    animeRecord.setDirty(true);
             } else {
                 mangaRecord = (Manga) result;
-                if (isAdded() && AccountService.isMAL())
-                    mangaRecord.setDirty(true);
             }
             setRefreshing(false);
             toggleLoadingIndicator(false);

--- a/Atarashii/src/net/somethingdreadful/MAL/DetailViewGeneral.java
+++ b/Atarashii/src/net/somethingdreadful/MAL/DetailViewGeneral.java
@@ -25,8 +25,8 @@ import com.squareup.picasso.Target;
 import net.somethingdreadful.MAL.api.MALApi;
 import net.somethingdreadful.MAL.api.MALApi.ListType;
 import net.somethingdreadful.MAL.api.response.GenericRecord;
-import net.somethingdreadful.MAL.dialog.NumberPickerDialogFragment;
 import net.somethingdreadful.MAL.dialog.MangaPickerDialogFragment;
+import net.somethingdreadful.MAL.dialog.NumberPickerDialogFragment;
 import net.somethingdreadful.MAL.dialog.StatusPickerDialogFragment;
 
 import java.io.Serializable;
@@ -165,7 +165,7 @@ public class DetailViewGeneral extends Fragment implements Serializable, OnRatin
         setMenu();
         if (activity.type.equals(ListType.ANIME)) {
             record = activity.animeRecord;
-            
+
             if (activity.isAdded()) {
                 status.setText(activity.getUserStatusString(activity.animeRecord.getWatchedStatusInt()));
                 cardPersonal.setVisibility(View.VISIBLE);
@@ -281,12 +281,10 @@ public class DetailViewGeneral extends Fragment implements Serializable, OnRatin
             if (activity.type.equals(ListType.ANIME)) {
                 if (activity.animeRecord != null) {
                     activity.animeRecord.setScore((int) (rating * 2));
-                    activity.animeRecord.setDirty(true);
                 }
             } else {
                 if (activity.mangaRecord != null) {
                     activity.mangaRecord.setScore((int) (rating * 2));
-                    activity.mangaRecord.setDirty(true);
                 }
             }
             activity.setText();

--- a/Atarashii/src/net/somethingdreadful/MAL/IGF.java
+++ b/Atarashii/src/net/somethingdreadful/MAL/IGF.java
@@ -233,12 +233,10 @@ public class IGF extends Fragment implements OnScrollListener, OnItemClickListen
             anime.setWatchedStatus(GenericRecord.STATUS_COMPLETED);
             if (anime.getEpisodes() > 0)
                 anime.setWatchedEpisodes(anime.getEpisodes());
-            anime.setDirty(true);
             gl.remove(anime);
             new WriteDetailTask(listType, TaskJob.UPDATE, context, getAuthErrorCallback()).execute(anime);
         } else {
             manga.setReadStatus(GenericRecord.STATUS_COMPLETED);
-            manga.setDirty(true);
             gl.remove(manga);
             new WriteDetailTask(listType, TaskJob.UPDATE, context, getAuthErrorCallback()).execute(manga);
         }

--- a/Atarashii/src/net/somethingdreadful/MAL/MALManager.java
+++ b/Atarashii/src/net/somethingdreadful/MAL/MALManager.java
@@ -231,7 +231,7 @@ public class MALManager {
     }
 
     public Anime updateWithDetails(int id, Anime anime, String username) {
-        Crashlytics.log(Log.DEBUG, "MALX", "MALManager.updateWithDetails("+ Integer.toString(id) + ", " + username + ")");
+        Crashlytics.log(Log.DEBUG, "MALX", "MALManager.updateWithDetails(" + Integer.toString(id) + ", " + username + ")");
         Anime anime_api;
         if (AccountService.isMAL())
             anime_api = malApi.getAnime(id);
@@ -375,7 +375,7 @@ public class MALManager {
             for (Anime anime : dirtyAnimes) {
                 totalSuccess = writeAnimeDetailsToMAL(anime);
                 if (totalSuccess) {
-                    anime.setDirty(false);
+                    anime.clearDirty();
                     saveAnimeToDatabase(anime, false, username);
                 }
 
@@ -398,7 +398,7 @@ public class MALManager {
             for (Manga manga : dirtyMangas) {
                 totalSuccess = writeMangaDetailsToMAL(manga);
                 if (totalSuccess) {
-                    manga.setDirty(false);
+                    manga.clearDirty();
                     saveMangaToDatabase(manga, false, username);
                 }
 

--- a/Atarashii/src/net/somethingdreadful/MAL/api/MALApi.java
+++ b/Atarashii/src/net/somethingdreadful/MAL/api/MALApi.java
@@ -25,6 +25,7 @@ import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.params.HttpProtocolParams;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 
 import retrofit.RestAdapter;
 import retrofit.RetrofitError;
@@ -124,8 +125,30 @@ public class MALApi {
         boolean result;
         if (anime.getCreateFlag())
             result = service.addAnime(anime.getId(), anime.getWatchedStatus(), anime.getWatchedEpisodes(), anime.getScore()).getStatus() == 200;
-        else
-            result = service.updateAnime(anime.getId(), anime.getWatchedStatus(), anime.getWatchedEpisodes(), anime.getScore(), anime.getWatchingStart(), anime.getWatchingEnd()).getStatus() == 200;
+        else {
+            if (anime.isDirty()) {
+                // map anime property names to api field names
+                HashMap<String, String> nameMap = new HashMap<>();
+                nameMap.put("watchedStatus", "status");
+                nameMap.put("watchedEpisodes", "episodes");
+                nameMap.put("score", "score");
+                nameMap.put("watchingStart", "start");
+                nameMap.put("watchingEnd", "end");
+                HashMap<String, String> fieldMap = new HashMap<>();
+                for (String dirtyField : anime.getDirty()) {
+                    if (nameMap.containsKey(dirtyField)) {
+                        if (anime.getPropertyType(dirtyField) == String.class) {
+                            fieldMap.put(nameMap.get(dirtyField), anime.getStringPropertyValue(dirtyField));
+                        } else if (anime.getPropertyType(dirtyField) == int.class) {
+                            fieldMap.put(nameMap.get(dirtyField), anime.getIntegerPropertyValue(dirtyField).toString());
+                        }
+                    }
+                }
+                result = service.updateAnime(anime.getId(), fieldMap).getStatus() == 200;
+            } else {
+                result = false;
+            }
+        }
         return result;
     }
 
@@ -133,8 +156,31 @@ public class MALApi {
         boolean result;
         if (manga.getCreateFlag())
             result = service.addManga(manga.getId(), manga.getReadStatus(), manga.getChaptersRead(), manga.getVolumesRead(), manga.getScore()).getStatus() == 200;
-        else
-            result = service.updateManga(manga.getId(), manga.getReadStatus(), manga.getChaptersRead(), manga.getVolumesRead(), manga.getScore(), manga.getReadingStart(), manga.getReadingEnd()).getStatus() == 200;
+        else {
+            if (manga.isDirty()) {
+                // map manga property names to api field names
+                HashMap<String, String> nameMap = new HashMap<>();
+                nameMap.put("readStatus", "status");
+                nameMap.put("chaptersRead", "chapters");
+                nameMap.put("volumesRead", "volumes");
+                nameMap.put("score", "score");
+                nameMap.put("readingStart", "start");
+                nameMap.put("readingEnd", "end");
+                HashMap<String, String> fieldMap = new HashMap<>();
+                for (String dirtyField : manga.getDirty()) {
+                    if (nameMap.containsKey(dirtyField)) {
+                        if (manga.getPropertyType(dirtyField) == String.class) {
+                            fieldMap.put(nameMap.get(dirtyField), manga.getStringPropertyValue(dirtyField));
+                        } else if (manga.getPropertyType(dirtyField) == int.class) {
+                            fieldMap.put(nameMap.get(dirtyField), manga.getIntegerPropertyValue(dirtyField).toString());
+                        }
+                    }
+                }
+                result = service.updateManga(manga.getId(), fieldMap).getStatus() == 200;
+            } else {
+                result = false;
+            }
+        }
         return result;
     }
 

--- a/Atarashii/src/net/somethingdreadful/MAL/api/MALInterface.java
+++ b/Atarashii/src/net/somethingdreadful/MAL/api/MALInterface.java
@@ -9,10 +9,12 @@ import net.somethingdreadful.MAL.api.response.Profile;
 import net.somethingdreadful.MAL.api.response.User;
 
 import java.util.ArrayList;
+import java.util.Map;
 
 import retrofit.client.Response;
 import retrofit.http.DELETE;
 import retrofit.http.Field;
+import retrofit.http.FieldMap;
 import retrofit.http.FormUrlEncoded;
 import retrofit.http.GET;
 import retrofit.http.POST;
@@ -55,8 +57,7 @@ public interface MALInterface {
 
     @FormUrlEncoded
     @PUT("/animelist/anime/{anime_id}")
-    Response updateAnime(@Path("anime_id") int id, @Field("status") String status, @Field("episodes") int episodes,
-                         @Field("score") int score, @Field("start") String start, @Field("end") String end);
+    Response updateAnime(@Path("anime_id") int id, @FieldMap Map<String, String> params);
 
     @GET("/manga/{manga_id}?mine=1")
     Manga getManga(@Path("manga_id") int manga_id);
@@ -89,8 +90,7 @@ public interface MALInterface {
 
     @FormUrlEncoded
     @PUT("/mangalist/manga/{manga_id}")
-    Response updateManga(@Path("manga_id") int id, @Field("status") String status, @Field("chapters") int chapters,
-                         @Field("volumes") int volumes, @Field("score") int score, @Field("start") String readingStart, @Field("end") String readingEnd);
+    Response updateManga(@Path("manga_id") int id, @FieldMap Map<String, String> params);
 
     @GET("/profile/{username}")
     Profile getProfile(@Path("username") String username);

--- a/Atarashii/src/net/somethingdreadful/MAL/api/response/Anime.java
+++ b/Atarashii/src/net/somethingdreadful/MAL/api/response/Anime.java
@@ -3,6 +3,7 @@ package net.somethingdreadful.MAL.api.response;
 import android.database.Cursor;
 import android.text.TextUtils;
 
+import com.google.gson.Gson;
 import com.google.gson.annotations.SerializedName;
 
 import net.somethingdreadful.MAL.sql.MALSqlHelper;
@@ -24,22 +25,22 @@ public class Anime extends GenericRecord implements Serializable {
 
     // MyAnimeList
     @Setter @Getter private int episodes;
-    @Setter @Getter @SerializedName("watched_status") private String watchedStatus;
-    @Setter @Getter @SerializedName("watched_episodes") private int watchedEpisodes;
+    @Getter @SerializedName("watched_status") private String watchedStatus;
+    @Getter @SerializedName("watched_episodes") private int watchedEpisodes;
     @Setter @Getter private String classification;
     @Setter @Getter @SerializedName("listed_anime_id") private int listedId;
-    @Setter @Getter @SerializedName("fansub_group") private String fansubGroup;
+    @Getter @SerializedName("fansub_group") private String fansubGroup;
     @Setter @Getter private ArrayList<String> producers;
-    @Setter @Getter @SerializedName("eps_downloaded") private int epsDownloaded;
-    @Setter @Getter @SerializedName("rewatch_count") private int rewatchCount;
-    @Setter @Getter @SerializedName("rewatch_value") private int rewatchValue;
+    @Getter @SerializedName("eps_downloaded") private int epsDownloaded;
+    @Getter @SerializedName("rewatch_count") private int rewatchCount;
+    @Getter @SerializedName("rewatch_value") private int rewatchValue;
     @Setter @Getter @SerializedName("start_date") private String startDate;
     @Setter @Getter @SerializedName("end_date") private String endDate;
-    @Setter @Getter @SerializedName("watching_start") private String watchingStart;
-    @Setter @Getter @SerializedName("watching_end") private String watchingEnd;
+    @Getter @SerializedName("watching_start") private String watchingStart;
+    @Getter @SerializedName("watching_end") private String watchingEnd;
     @Setter private boolean rewatching;
-    @Setter @Getter @SerializedName("storage_value") private int storageValue;
-    @Setter @Getter private int storage;
+    @Getter @SerializedName("storage_value") private int storageValue;
+    @Getter private int storage;
     @Setter @Getter @SerializedName("alternative_versions") private ArrayList<RecordStub> alternativeVersions;
     @Setter @Getter @SerializedName("character_anime") private ArrayList<RecordStub> characterAnime;
     @Setter @Getter private ArrayList<RecordStub> prequels;
@@ -105,8 +106,8 @@ public class Anime extends GenericRecord implements Serializable {
         result.setTitle(c.getString(columnNames.indexOf("recordName")));
         result.setType(c.getString(columnNames.indexOf("recordType")));
         result.setStatus(c.getString(columnNames.indexOf("recordStatus")));
-        result.setWatchedStatus(c.getString(columnNames.indexOf("myStatus")));
-        result.setWatchedEpisodes(c.getInt(columnNames.indexOf("episodesWatched")));
+        result.setWatchedStatus(c.getString(columnNames.indexOf("myStatus")), false);
+        result.setWatchedEpisodes(c.getInt(columnNames.indexOf("episodesWatched")), false);
         result.setEpisodes(c.getInt(columnNames.indexOf("episodesTotal")));
         result.setWatchingStart(c.getString(columnNames.indexOf("watchedStart")));
         result.setStorage(c.getInt(columnNames.indexOf("storage")));
@@ -116,14 +117,14 @@ public class Anime extends GenericRecord implements Serializable {
         result.setScore(c.getInt(columnNames.indexOf("myScore")));
         result.setSynopsis(c.getString(columnNames.indexOf("synopsis")));
         result.setImageUrl(c.getString(columnNames.indexOf("imageUrl")));
-        result.setDirty(c.getInt(columnNames.indexOf("dirty")) > 0);
+        result.setDirty(new Gson().fromJson(c.getString(columnNames.indexOf("dirty")),ArrayList.class));
         result.setClassification(c.getString(columnNames.indexOf("classification")));
         result.setMembersCount(c.getInt(columnNames.indexOf("membersCount")));
         result.setFavoritedCount(c.getInt(columnNames.indexOf("favoritedCount")));
         result.setPopularityRank(c.getInt(columnNames.indexOf("popularityRank")));
         result.setWatchingStart(c.getString(columnNames.indexOf("watchedStart")));
         result.setWatchingEnd(c.getString(columnNames.indexOf("watchedEnd")));
-        result.setFansubGroup(c.getString(columnNames.indexOf("fansub")));
+        result.setFansubGroup(c.getString(columnNames.indexOf("fansub")), false);
         result.setPriority(c.getInt(columnNames.indexOf("priority")));
         result.setEpsDownloaded(c.getInt(columnNames.indexOf("downloaded")));
         result.setRewatchCount(c.getInt(columnNames.indexOf("rewatchCount")));
@@ -188,5 +189,115 @@ public class Anime extends GenericRecord implements Serializable {
 
     public String getProducersString() {
         return getProducers() != null ? TextUtils.join(", ", getProducers()) : "";
+    }
+
+    public void setWatchedStatus(String status, boolean markDirty) {
+        this.watchedStatus = status;
+        if (markDirty) {
+            addDirtyField("watchedStatus");
+        }
+    }
+
+    public void setWatchedStatus(String status) {
+        setWatchedStatus(status, true);
+    }
+
+    public void setWatchedEpisodes(int episodes, boolean markDirty) {
+        this.watchedEpisodes = episodes;
+        if (markDirty) {
+            addDirtyField("watchedEpisodes");
+        }
+    }
+
+    public void setWatchedEpisodes(int episodes) {
+        setWatchedEpisodes(episodes, true);
+    }
+
+    public void setFansubGroup(String group, boolean markDirty) {
+        this.fansubGroup = group;
+        if (markDirty) {
+            addDirtyField("fansubGroup");
+        }
+    }
+
+    public void setFansubGroup(String group) {
+        setFansubGroup(group, true);
+    }
+
+    public void setEpsDownloaded(int episodes, boolean markDirty) {
+        this.epsDownloaded = episodes;
+        if (markDirty) {
+            addDirtyField("epsDownloaded");
+        }
+    }
+
+    public void setEpsDownloaded(int episodes) {
+        setEpsDownloaded(episodes, true);
+    }
+
+    public void setRewatchCount(int count, boolean markDirty) {
+        this.rewatchCount = count;
+        if (markDirty) {
+            addDirtyField("rewatchCount");
+        }
+    }
+
+    public void setRewatchCount(int count) {
+        setRewatchCount(count, true);
+    }
+
+    public void setRewatchValue(int value, boolean markDirty) {
+        this.rewatchValue = value;
+        if (markDirty) {
+            addDirtyField("rewatchValue");
+        }
+    }
+
+    public void setRewatchValue(int value) {
+        setRewatchValue(value, true);
+    }
+
+    public void setWatchingStart(String start, boolean markDirty) {
+        this.watchingStart = start;
+        if (markDirty) {
+            addDirtyField("watchingStart");
+        }
+    }
+
+    public void setWatchingStart(String start) {
+        setWatchingStart(start, true);
+    }
+
+    public void setWatchingEnd(String end, boolean markDirty) {
+        this.watchingEnd = end;
+        if (markDirty) {
+            addDirtyField("watchingEnd");
+        }
+    }
+
+    public void setWatchingEnd(String end) {
+        setWatchingEnd(end, true);
+    }
+
+    public void setStorageValue(int value, boolean markDirty) {
+        this.storageValue = value;
+        if (markDirty) {
+            addDirtyField("storageValue");
+        }
+    }
+
+    public void setStorageValue(int value) {
+        setStorageValue(value, true);
+    }
+
+    public void setStorage(int storage, boolean markDirty) {
+        this.storage = storage;
+        if (markDirty) {
+            addDirtyField("storage");
+        }
+    }
+
+    public void setStorage(int storage) {
+        setStorageValue(storage, true);
     }
 }

--- a/Atarashii/src/net/somethingdreadful/MAL/api/response/Anime.java
+++ b/Atarashii/src/net/somethingdreadful/MAL/api/response/Anime.java
@@ -9,6 +9,7 @@ import com.google.gson.annotations.SerializedName;
 import net.somethingdreadful.MAL.sql.MALSqlHelper;
 
 import java.io.Serializable;
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -109,26 +110,30 @@ public class Anime extends GenericRecord implements Serializable {
         result.setWatchedStatus(c.getString(columnNames.indexOf("myStatus")), false);
         result.setWatchedEpisodes(c.getInt(columnNames.indexOf("episodesWatched")), false);
         result.setEpisodes(c.getInt(columnNames.indexOf("episodesTotal")));
-        result.setWatchingStart(c.getString(columnNames.indexOf("watchedStart")));
-        result.setStorage(c.getInt(columnNames.indexOf("storage")));
-        result.setStorageValue(c.getInt(columnNames.indexOf("storageValue")));
-        result.setWatchingEnd(c.getString(columnNames.indexOf("watchedEnd")));
+        result.setWatchingStart(c.getString(columnNames.indexOf("watchedStart")), false);
+        result.setStorage(c.getInt(columnNames.indexOf("storage")), false);
+        result.setStorageValue(c.getInt(columnNames.indexOf("storageValue")), false);
+        result.setWatchingEnd(c.getString(columnNames.indexOf("watchedEnd")), false);
         result.setMembersScore(c.getFloat(columnNames.indexOf("memberScore")));
         result.setScore(c.getInt(columnNames.indexOf("myScore")));
         result.setSynopsis(c.getString(columnNames.indexOf("synopsis")));
         result.setImageUrl(c.getString(columnNames.indexOf("imageUrl")));
-        result.setDirty(new Gson().fromJson(c.getString(columnNames.indexOf("dirty")),ArrayList.class));
+        if (!c.isNull(columnNames.indexOf("dirty"))) {
+            result.setDirty(new Gson().fromJson(c.getString(columnNames.indexOf("dirty")), ArrayList.class));
+        } else {
+            result.setDirty(null);
+        }
         result.setClassification(c.getString(columnNames.indexOf("classification")));
         result.setMembersCount(c.getInt(columnNames.indexOf("membersCount")));
         result.setFavoritedCount(c.getInt(columnNames.indexOf("favoritedCount")));
         result.setPopularityRank(c.getInt(columnNames.indexOf("popularityRank")));
-        result.setWatchingStart(c.getString(columnNames.indexOf("watchedStart")));
-        result.setWatchingEnd(c.getString(columnNames.indexOf("watchedEnd")));
+        result.setWatchingStart(c.getString(columnNames.indexOf("watchedStart")), false);
+        result.setWatchingEnd(c.getString(columnNames.indexOf("watchedEnd")), false);
         result.setFansubGroup(c.getString(columnNames.indexOf("fansub")), false);
         result.setPriority(c.getInt(columnNames.indexOf("priority")));
-        result.setEpsDownloaded(c.getInt(columnNames.indexOf("downloaded")));
-        result.setRewatchCount(c.getInt(columnNames.indexOf("rewatchCount")));
-        result.setRewatchValue(c.getInt(columnNames.indexOf("rewatchValue")));
+        result.setEpsDownloaded(c.getInt(columnNames.indexOf("downloaded")), false);
+        result.setRewatchCount(c.getInt(columnNames.indexOf("rewatchCount")), false);
+        result.setRewatchValue(c.getInt(columnNames.indexOf("rewatchValue")), false);
         result.setRewatching(c.getInt(columnNames.indexOf("rewatch")) > 0);
         result.setPersonalComments(c.getString(columnNames.indexOf("comments")));
         result.setStartDate(c.getString(columnNames.indexOf("startDate")));

--- a/Atarashii/src/net/somethingdreadful/MAL/api/response/GenericRecord.java
+++ b/Atarashii/src/net/somethingdreadful/MAL/api/response/GenericRecord.java
@@ -45,7 +45,7 @@ public class GenericRecord implements Serializable {
     @Setter @Getter private String synopsis;
     @Setter @Getter @SerializedName("other_titles") private HashMap<String, ArrayList<String>> otherTitles;
 
-    @Setter private boolean dirty;
+    @Setter @Getter private ArrayList<String> dirty;
     @Setter @Getter private Date lastUpdate;
     @Setter private boolean createFlag;
     @Setter private boolean deleteFlag;
@@ -70,9 +70,23 @@ public class GenericRecord implements Serializable {
         return deleteFlag;
     }
 
-    // Note: @Getter is not working on booleans
-    public boolean getDirty() {
+    public ArrayList<String> getDirty() {
         return dirty;
+    }
+
+    public void addDirtyField(String field) {
+        if  (dirty == null) {
+            dirty = new ArrayList<String>();
+        }
+        if (!dirty.contains((field))) {
+            dirty.add(field);
+        }
+    }
+
+    public void clearDirty() {
+        if (dirty != null) {
+            dirty.clear();
+        }
     }
 
     public ArrayList<Integer> getGenresInt() {
@@ -97,7 +111,7 @@ public class GenericRecord implements Serializable {
         if (getGenres() != null)
             for (String genre : getGenres())
                 result.add(Arrays.asList(genres).indexOf(genre));
-        
+
         return result;
     }
 

--- a/Atarashii/src/net/somethingdreadful/MAL/api/response/GenericRecord.java
+++ b/Atarashii/src/net/somethingdreadful/MAL/api/response/GenericRecord.java
@@ -9,6 +9,7 @@ import com.google.gson.annotations.SerializedName;
 import net.somethingdreadful.MAL.account.AccountService;
 
 import java.io.Serializable;
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -36,7 +37,7 @@ public class GenericRecord implements Serializable {
     @Setter @Getter private int priority;
     @Setter @Getter @SerializedName("personal_comments") private String personalComments;
     @Getter @SerializedName("personal_tags") private ArrayList<String> personalTags;
-    @Setter @Getter private int score;
+    @Getter private int score;
     @Setter @Getter private int rank;
     @Setter @Getter @SerializedName("members_score") private float membersScore;
     @Setter @Getter @SerializedName("members_count") private int membersCount;
@@ -84,9 +85,7 @@ public class GenericRecord implements Serializable {
     }
 
     public void clearDirty() {
-        if (dirty != null) {
-            dirty.clear();
-        }
+        dirty = null;
     }
 
     public ArrayList<Integer> getGenresInt() {
@@ -164,5 +163,61 @@ public class GenericRecord implements Serializable {
                 "plan to read"
         };
         return Arrays.asList(status).indexOf(statusString);
+    }
+
+    public void setScore(int value) {
+        setScore(value, true);
+    }
+
+    public void setScore(int value, boolean markDirty) {
+        this.score = value;
+        if (markDirty) {
+            addDirtyField("score");
+        }
+    }
+
+    public boolean isDirty() {
+        if (dirty == null) {
+            return false;
+        }
+        return !dirty.isEmpty();
+    }
+
+    /*
+     * some reflection magic used to get dirty values easier
+     */
+    public Class getPropertyType(String property) {
+        try {
+            Field field = this.getClass().getDeclaredField(property);
+            return field.getType();
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    protected Object getPropertyValue(String property) {
+        try {
+            Field field = this.getClass().getDeclaredField(property);
+            field.setAccessible(true);
+            return field.get(this);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    public Integer getIntegerPropertyValue(String property) {
+        Object value = getPropertyValue(property);
+        if (value != null) {
+            return (Integer) value;
+        }
+        return null;
+    }
+
+    public String getStringPropertyValue(String property) {
+        Object value = getPropertyValue(property);
+        if (value != null) {
+            return (String) value;
+        }
+        return null;
     }
 }

--- a/Atarashii/src/net/somethingdreadful/MAL/api/response/GenericRecord.java
+++ b/Atarashii/src/net/somethingdreadful/MAL/api/response/GenericRecord.java
@@ -76,7 +76,7 @@ public class GenericRecord implements Serializable {
     }
 
     public void addDirtyField(String field) {
-        if  (dirty == null) {
+        if (dirty == null) {
             dirty = new ArrayList<String>();
         }
         if (!dirty.contains((field))) {
@@ -188,19 +188,34 @@ public class GenericRecord implements Serializable {
      */
     public Class getPropertyType(String property) {
         try {
-            Field field = this.getClass().getDeclaredField(property);
+            Field field = getField(this.getClass(), property);
             return field.getType();
         } catch (Exception e) {
             return null;
         }
     }
 
+    private Field getField(Class<?> c, String property) {
+        try {
+            return c.getDeclaredField(property);
+        } catch (Exception e) {
+            if (c.getSuperclass() != null) {
+                return getField(c.getSuperclass(), property);
+            } else {
+                return null;
+            }
+        }
+    }
+
     protected Object getPropertyValue(String property) {
         try {
-            Field field = this.getClass().getDeclaredField(property);
-            field.setAccessible(true);
-            return field.get(this);
-        } catch (Exception e) {
+            Field field = getField(this.getClass(), property);
+            if (field != null) {
+                field.setAccessible(true);
+                return field.get(this);
+            }
+            return null;
+        } catch (IllegalAccessException e) {
             return null;
         }
     }

--- a/Atarashii/src/net/somethingdreadful/MAL/api/response/Manga.java
+++ b/Atarashii/src/net/somethingdreadful/MAL/api/response/Manga.java
@@ -26,15 +26,15 @@ public class Manga extends GenericRecord implements Serializable {
     @Setter @Getter @SerializedName("anime_adaptations") ArrayList<RecordStub> animeAdaptations;
     @Setter @Getter private int chapters;
     @Setter @Getter private int volumes;
-    @Setter @Getter @SerializedName("read_status") private String readStatus;
-    @Setter @Getter @SerializedName("chapters_read") private int chaptersRead;
-    @Setter @Getter @SerializedName("volumes_read") private int volumesRead;
+    @Getter @SerializedName("read_status") private String readStatus;
+    @Getter @SerializedName("chapters_read") private int chaptersRead;
+    @Getter @SerializedName("volumes_read") private int volumesRead;
     @Setter @Getter @SerializedName("listed_manga_id") private int listedId;
-    @Setter @Getter @SerializedName("reading_start") private String readingStart;
-    @Setter @Getter @SerializedName("reading_end") private String readingEnd;
-    @Setter @Getter @SerializedName("chap_downloaded") private int chapDownloaded;
-    @Setter @Getter @SerializedName("rereading") private boolean rereading;
-    @Setter @Getter @SerializedName("reread_count") private int rereadCount;
+    @Getter @SerializedName("reading_start") private String readingStart;
+    @Getter @SerializedName("reading_end") private String readingEnd;
+    @Getter @SerializedName("chap_downloaded") private int chapDownloaded;
+    @Getter @SerializedName("rereading") private boolean rereading;
+    @Getter @SerializedName("reread_count") private int rereadCount;
     @Setter @Getter @SerializedName("reread_value") private int rereadValue;
 
     // AniList
@@ -69,7 +69,7 @@ public class Manga extends GenericRecord implements Serializable {
             setVolumes(total_volumes);
             setChapters(total_chapters);
         }
-        setReadStatus(list_status);
+        setReadStatus(list_status, false);
         return this;
     }
 
@@ -81,29 +81,31 @@ public class Manga extends GenericRecord implements Serializable {
         result.setTitle(c.getString(columnNames.indexOf("recordName")));
         result.setType(c.getString(columnNames.indexOf("recordType")));
         result.setStatus(c.getString(columnNames.indexOf("recordStatus")));
-        result.setReadStatus(c.getString(columnNames.indexOf("myStatus")));
-        result.setVolumesRead(c.getInt(columnNames.indexOf("volumesRead")));
-        result.setChaptersRead(c.getInt(columnNames.indexOf("chaptersRead")));
-        result.setReadingStart(c.getString(columnNames.indexOf("readStart")));
-        result.setReadingEnd(c.getString(columnNames.indexOf("readEnd")));
+        result.setReadStatus(c.getString(columnNames.indexOf("myStatus")), false);
+        result.setVolumesRead(c.getInt(columnNames.indexOf("volumesRead")), false);
+        result.setChaptersRead(c.getInt(columnNames.indexOf("chaptersRead")), false);
+        result.setReadingStart(c.getString(columnNames.indexOf("readStart")), false);
+        result.setReadingEnd(c.getString(columnNames.indexOf("readEnd")), false);
         result.setVolumes(c.getInt(columnNames.indexOf("volumesTotal")));
         result.setChapters(c.getInt(columnNames.indexOf("chaptersTotal")));
         result.setMembersScore(c.getFloat(columnNames.indexOf("memberScore")));
         result.setScore(c.getInt(columnNames.indexOf("myScore")));
         result.setSynopsis(c.getString(columnNames.indexOf("synopsis")));
         result.setImageUrl(c.getString(columnNames.indexOf("imageUrl")));
-        result.setDirty(new Gson().fromJson(c.getString(columnNames.indexOf("dirty")),ArrayList.class));
+        if (!c.isNull(columnNames.indexOf("dirty"))) {
+            result.setDirty(new Gson().fromJson(c.getString(columnNames.indexOf("dirty")), ArrayList.class));
+        } else {
+            result.setDirty(null);
+        }
         result.setMembersCount(c.getInt(columnNames.indexOf("membersCount")));
         result.setFavoritedCount(c.getInt(columnNames.indexOf("favoritedCount")));
         result.setPopularityRank(c.getInt(columnNames.indexOf("popularityRank")));
         result.setRank(c.getInt(columnNames.indexOf("rank")));
         result.setListedId(c.getInt(columnNames.indexOf("listedId")));
-        result.setReadingStart(c.getString(columnNames.indexOf("readStart")));
-        result.setReadingEnd(c.getString(columnNames.indexOf("readEnd")));
         result.setPriority(c.getInt(columnNames.indexOf("priority")));
-        result.setChapDownloaded(c.getInt(columnNames.indexOf("downloaded")));
-        result.setRereading(c.getInt(columnNames.indexOf("rereading")) > 0);
-        result.setRereadCount(c.getInt(columnNames.indexOf("rereadCount")));
+        result.setChapDownloaded(c.getInt(columnNames.indexOf("downloaded")), false);
+        result.setRereading(c.getInt(columnNames.indexOf("rereading")) > 0, false);
+        result.setRereadCount(c.getInt(columnNames.indexOf("rereadCount")), false);
         result.setPersonalComments(c.getString(columnNames.indexOf("comments")));
         Date lastUpdateDate;
         try {
@@ -155,5 +157,93 @@ public class Manga extends GenericRecord implements Serializable {
 
     public int getTotal(boolean useSecondaryAmount) {
         return useSecondaryAmount ? getVolumes() : getChapters();
+    }
+
+    public void setReadStatus(String value, boolean markDirty) {
+        this.readStatus = value;
+        if (markDirty) {
+            addDirtyField("readStatus");
+        }
+    }
+
+    public void setReadStatus(String value) {
+        setReadStatus(value, true);
+    }
+
+    public void setChaptersRead(int value, boolean markDirty) {
+        this.chaptersRead = value;
+        if (markDirty) {
+            addDirtyField("chaptersRead");
+        }
+    }
+
+    public void setChaptersRead(int value) {
+        setChaptersRead(value, true);
+    }
+
+    public void setVolumesRead(int value, boolean markDirty) {
+        this.volumesRead = value;
+        if (markDirty) {
+            addDirtyField("volumesRead");
+        }
+    }
+
+    public void setVolumesRead(int value) {
+        setVolumesRead(value, true);
+    }
+
+    public void setReadingStart(String value, boolean markDirty) {
+        this.readingStart = value;
+        if (markDirty) {
+            addDirtyField("readingStart");
+        }
+    }
+
+    public void setReadingStart(String value) {
+        setReadingStart(value, true);
+    }
+
+    public void setReadingEnd(String value, boolean markDirty) {
+        this.readingEnd = value;
+        if (markDirty) {
+            addDirtyField("readingEnd");
+        }
+    }
+
+    public void setReadingEnd(String value) {
+        setReadingEnd(value, true);
+    }
+
+    public void setChapDownloaded(int value, boolean markDirty) {
+        this.chapDownloaded = value;
+        if (markDirty) {
+            addDirtyField("chapDownloaded");
+        }
+    }
+
+    public void setChapDownloaded(int value) {
+        setChapDownloaded(value, true);
+    }
+
+    public void setRereading(boolean value, boolean markDirty) {
+        this.rereading = value;
+        if (markDirty) {
+            addDirtyField("rereading");
+        }
+    }
+
+    public void setRereading(boolean value) {
+        setRereading(value, true);
+    }
+
+    public void setRereadCount(int value, boolean markDirty) {
+        this.rereadCount = value;
+        if (markDirty) {
+            addDirtyField("rereadCount");
+        }
+    }
+
+    public void setRereadCount(int value) {
+        setRereadCount(value, true);
     }
 }

--- a/Atarashii/src/net/somethingdreadful/MAL/api/response/Manga.java
+++ b/Atarashii/src/net/somethingdreadful/MAL/api/response/Manga.java
@@ -2,6 +2,7 @@ package net.somethingdreadful.MAL.api.response;
 
 import android.database.Cursor;
 
+import com.google.gson.Gson;
 import com.google.gson.annotations.SerializedName;
 
 import net.somethingdreadful.MAL.sql.MALSqlHelper;
@@ -91,7 +92,7 @@ public class Manga extends GenericRecord implements Serializable {
         result.setScore(c.getInt(columnNames.indexOf("myScore")));
         result.setSynopsis(c.getString(columnNames.indexOf("synopsis")));
         result.setImageUrl(c.getString(columnNames.indexOf("imageUrl")));
-        result.setDirty(c.getInt(columnNames.indexOf("dirty")) > 0);
+        result.setDirty(new Gson().fromJson(c.getString(columnNames.indexOf("dirty")),ArrayList.class));
         result.setMembersCount(c.getInt(columnNames.indexOf("membersCount")));
         result.setFavoritedCount(c.getInt(columnNames.indexOf("favoritedCount")));
         result.setPopularityRank(c.getInt(columnNames.indexOf("popularityRank")));

--- a/Atarashii/src/net/somethingdreadful/MAL/sql/DatabaseManager.java
+++ b/Atarashii/src/net/somethingdreadful/MAL/sql/DatabaseManager.java
@@ -228,7 +228,7 @@ public class DatabaseManager {
                 alcv.put("rewatchCount", anime.getRewatchCount());
                 alcv.put("rewatchValue", anime.getRewatchValue());
                 alcv.put("comments", anime.getPersonalComments());
-                alcv.put("dirty", new Gson().toJson(anime.getDirty()));
+                alcv.put("dirty", anime.getDirty() != null ? new Gson().toJson(anime.getDirty()) : null);
                 if (anime.getLastUpdate() != null)
                     alcv.put("lastUpdate", anime.getLastUpdate().getTime());
                 getDBWrite().replace(MALSqlHelper.TABLE_ANIMELIST, null, alcv);
@@ -349,12 +349,12 @@ public class DatabaseManager {
                 cursor = getDBRead().rawQuery("SELECT a.*, al.score AS myScore, al.status AS myStatus, al.watched AS episodesWatched, al.dirty, al.lastUpdate," +
                         " al.watchedStart, al.WatchedEnd, al.fansub, al.priority, al.downloaded, al.storage, al.storageValue, al.rewatch, al.rewatchCount, al.rewatchValue, al.comments" +
                         " FROM animelist al INNER JOIN anime a ON al.anime_id = a." + MALSqlHelper.COLUMN_ID +
-                        " WHERE al.profile_id = ? AND al.rewatch = 1 " + (dirtyOnly ? " AND al.dirty = 1 " : "") + " ORDER BY a.recordName COLLATE NOCASE", selArgs.toArray(new String[selArgs.size()]));
+                        " WHERE al.profile_id = ? AND al.rewatch = 1 " + (dirtyOnly ? " AND al.dirty IS NOT NULL " : "") + " ORDER BY a.recordName COLLATE NOCASE", selArgs.toArray(new String[selArgs.size()]));
             else
                 cursor = getDBRead().rawQuery("SELECT a.*, al.score AS myScore, al.status AS myStatus, al.watched AS episodesWatched, al.dirty, al.lastUpdate," +
                         " al.watchedStart, al.WatchedEnd, al.fansub, al.priority, al.downloaded, al.storage, al.storageValue, al.rewatch, al.rewatchCount, al.rewatchValue, al.comments" +
                         " FROM animelist al INNER JOIN anime a ON al.anime_id = a." + MALSqlHelper.COLUMN_ID +
-                        " WHERE al.profile_id = ? " + (listType != "" ? " AND al.status = ? " : "") + (dirtyOnly ? " AND al.dirty = 1 " : "") + " ORDER BY a.recordName COLLATE NOCASE", selArgs.toArray(new String[selArgs.size()]));
+                        " WHERE al.profile_id = ? " + (listType != "" ? " AND al.status = ? " : "") + (dirtyOnly ? " AND al.dirty IS NOT NULL " : "") + " ORDER BY a.recordName COLLATE NOCASE", selArgs.toArray(new String[selArgs.size()]));
             if (cursor.moveToFirst()) {
                 result = new ArrayList<Anime>();
                 do {
@@ -539,7 +539,7 @@ public class DatabaseManager {
                 mlcv.put("rereading", manga.getRereadValue());
                 mlcv.put("rereadCount", manga.getRereadCount());
                 mlcv.put("comments", manga.getPersonalComments());
-                mlcv.put("dirty", new Gson().toJson(manga.getDirty()));
+                mlcv.put("dirty", manga.getDirty() != null ? new Gson().toJson(manga.getDirty()) : null);
                 if (manga.getLastUpdate() != null)
                     mlcv.put("lastUpdate", manga.getLastUpdate().getTime());
                 getDBWrite().replace(MALSqlHelper.TABLE_MANGALIST, null, mlcv);
@@ -637,7 +637,7 @@ public class DatabaseManager {
             cursor = getDBRead().rawQuery("SELECT m.*, ml.score AS myScore, ml.status AS myStatus, ml.chaptersRead, ml.volumesRead, ml.readStart, ml.readEnd," +
                     " ml.priority, ml.downloaded, ml.rereading, ml.rereadCount, ml.comments, ml.dirty, ml.lastUpdate" +
                     " FROM mangalist ml INNER JOIN manga m ON ml.manga_id = m." + MALSqlHelper.COLUMN_ID +
-                    " WHERE ml.profile_id = ? " + (listType != "" ? " AND ml.status = ? " : "") + (dirtyOnly ? " AND ml.dirty = 1 " : "") + " ORDER BY m.recordName COLLATE NOCASE", selArgs.toArray(new String[selArgs.size()]));
+                    " WHERE ml.profile_id = ? " + (listType != "" ? " AND ml.status = ? " : "") + (dirtyOnly ? " AND ml.dirty <> \"\" " : "") + " ORDER BY m.recordName COLLATE NOCASE", selArgs.toArray(new String[selArgs.size()]));
             if (cursor.moveToFirst()) {
                 result = new ArrayList<Manga>();
                 do {

--- a/Atarashii/src/net/somethingdreadful/MAL/sql/DatabaseManager.java
+++ b/Atarashii/src/net/somethingdreadful/MAL/sql/DatabaseManager.java
@@ -8,6 +8,7 @@ import android.database.sqlite.SQLiteDatabase;
 import android.util.Log;
 
 import com.crashlytics.android.Crashlytics;
+import com.google.gson.Gson;
 
 import net.somethingdreadful.MAL.MALDateTools;
 import net.somethingdreadful.MAL.account.AccountService;
@@ -227,7 +228,7 @@ public class DatabaseManager {
                 alcv.put("rewatchCount", anime.getRewatchCount());
                 alcv.put("rewatchValue", anime.getRewatchValue());
                 alcv.put("comments", anime.getPersonalComments());
-                alcv.put("dirty", anime.getDirty());
+                alcv.put("dirty", new Gson().toJson(anime.getDirty()));
                 if (anime.getLastUpdate() != null)
                     alcv.put("lastUpdate", anime.getLastUpdate().getTime());
                 getDBWrite().replace(MALSqlHelper.TABLE_ANIMELIST, null, alcv);
@@ -538,7 +539,7 @@ public class DatabaseManager {
                 mlcv.put("rereading", manga.getRereadValue());
                 mlcv.put("rereadCount", manga.getRereadCount());
                 mlcv.put("comments", manga.getPersonalComments());
-                mlcv.put("dirty", manga.getDirty());
+                mlcv.put("dirty", new Gson().toJson(manga.getDirty()));
                 if (manga.getLastUpdate() != null)
                     mlcv.put("lastUpdate", manga.getLastUpdate().getTime());
                 getDBWrite().replace(MALSqlHelper.TABLE_MANGALIST, null, mlcv);

--- a/Atarashii/src/net/somethingdreadful/MAL/sql/MALSqlHelper.java
+++ b/Atarashii/src/net/somethingdreadful/MAL/sql/MALSqlHelper.java
@@ -132,7 +132,7 @@ public class MALSqlHelper extends SQLiteOpenHelper {
             + "rewatchCount integer, "
             + "rewatchValue integer, "
             + "comments varchar, "
-            + "dirty boolean DEFAULT false, "
+            + "dirty varchar DEFAULT NULL, "
             + "lastUpdate integer NOT NULL DEFAULT (strftime('%s','now')),"
             + "PRIMARY KEY(profile_id, anime_id)"
             + ");";
@@ -153,7 +153,7 @@ public class MALSqlHelper extends SQLiteOpenHelper {
             + "rereading boolean, "
             + "rereadCount integer, "
             + "comments varchar, "
-            + "dirty boolean DEFAULT false, "
+            + "dirty varchar DEFAULT NULL, "
             + "lastUpdate integer NOT NULL DEFAULT (strftime('%s','now')),"
             + "PRIMARY KEY(profile_id, manga_id)"
             + ");";
@@ -310,7 +310,7 @@ public class MALSqlHelper extends SQLiteOpenHelper {
             + ");";
 
     protected static final String DATABASE_NAME = "MAL.db";
-    private static final int DATABASE_VERSION = 10;
+    private static final int DATABASE_VERSION = 11;
     private static MALSqlHelper instance;
 
     public MALSqlHelper(Context context) {
@@ -589,6 +589,24 @@ public class MALSqlHelper extends SQLiteOpenHelper {
             db.execSQL(CREATE_ANIME_PRODUCER_TABLE);
             db.execSQL(CREATE_ANIME_PERSONALTAGS_TABLE);
             db.execSQL(CREATE_MANGA_PERSONALTAGS_TABLE);
+        }
+
+        if (oldVersion < 11) {
+            // update animelist table
+            db.execSQL("create table temp_table as select * from " + TABLE_ANIMELIST);
+            db.execSQL("update temp_table set dirty = NULL");
+            db.execSQL("drop table " + TABLE_ANIMELIST);
+            db.execSQL(CREATE_ANIMELIST_TABLE);
+            db.execSQL("insert into " + TABLE_ANIMELIST + " select * from temp_table;");
+            db.execSQL("drop table temp_table;");
+
+            // update mangalist table
+            db.execSQL("create table temp_table as select * from " + TABLE_MANGALIST);
+            db.execSQL("update temp_table set dirty = NULL");
+            db.execSQL("drop table " + TABLE_MANGALIST);
+            db.execSQL(CREATE_MANGALIST_TABLE);
+            db.execSQL("insert into " + TABLE_MANGALIST + " select * from temp_table;");
+            db.execSQL("drop table temp_table;");
         }
     }
 }

--- a/Atarashii/src/net/somethingdreadful/MAL/tasks/WriteDetailTask.java
+++ b/Atarashii/src/net/somethingdreadful/MAL/tasks/WriteDetailTask.java
@@ -47,10 +47,7 @@ public class WriteDetailTask extends AsyncTask<GenericRecord, Void, Boolean> {
                 } else {
                     manager.writeMangaDetailsToMAL((Manga) gr[0]);
                 }
-                gr[0].setDirty(false);
-            } else {
-                // currently no connection, mark record as dirty for later sync
-                gr[0].setDirty(true);
+                gr[0].clearDirty();
             }
         } catch (RetrofitError re) {
             if (re.getResponse() != null) {


### PR DESCRIPTION
This PR is a rewrite of the whole dirty flag stuff. Now it is possible to check which properties are changed.
To do this I have reintroduced some of the setter functions that were removed with the implementation of lombok. These setters now add the property name to dirty, which is a ArrayList now. There is also a second implementation of this setters which accept a second boolean argument which allows to define if the property should be marked as dirty (this is used when the record is loaded from the database by ``fromCursor()``).

Because of the new setter functions which mark the properties as dirty themselves we don't need to call ``setDirty()`` anymore after updating a value, which is a nice side effect.

The ``addOrUpdateAnime()``/``addOrUpdateManga()`` functions in ``MALApi`` read the changed properties by iterating through the dirty-ArrayList and getting the values by reflection (which makes it quite easy to get them) and pass them as FieldMap to the retrofit interface functions. This way the app always sends only changed properties to the API, not everything as until now (this only affects MAL currently, there should be no difference for AniList).